### PR TITLE
Add support for Force, Pressure, Energy and Power measurements (#13_v0)

### DIFF
--- a/.archive/implementation_plan_13.md
+++ b/.archive/implementation_plan_13.md
@@ -1,0 +1,241 @@
+# Implementation Plan — Issue #13: Add support for Force, Pressure, Energy and Power measurements
+
+## Task summary
+
+Add four new measurement families to the library — `Force`, `Pressure`, `Energy`, `Power` — each shipping as
+the same complete 4-class set every existing family uses: `<X>Unit` (enum), `<X>` (measurement class),
+`<X>Converter` (conversion logic), `<X>Formatter` (locale-aware formatting), plus mirrored unit tests for all
+four, and a row in README.md's "Supported measurement families" table. Per the issue's definition of done, a
+family is not complete unless all four classes + tests + README row exist — no partial family (e.g. converter
+without formatter) is acceptable.
+
+**Language/framework:** java (Maven)
+
+**Design decisions made (not specified by the issue, chosen from codebase convention):**
+
+- **Base/reference unit per family** (the unit every conversion routes through internally, following
+  `SpeedConverter`'s meters-per-second pattern): `Force` → `NEWTON`, `Pressure` → `PASCAL`, `Energy` → `JOULE`,
+  `Power` → `WATT` — the SI unit in each family, matching how every existing converter (`DistanceConverter` →
+  meter, `WeightConverter` → gram, `SpeedConverter` → m/s) uses the SI unit as its base.
+- **Conversion factors** (standard, well-established physical constants; each becomes a named
+  `static final double` field in its `*Converter` class per Checkstyle's `MagicNumber` rule, mirroring
+  `SpeedConverter`'s `METERS_PER_KILOMETER`, `METERS_PER_FOOT`, etc.):
+  - Force → base `NEWTON`: `KILONEWTON` = 1000 N, `POUND_FORCE` = 4.4482216152605 N, `DYNE` = 0.00001 N,
+    `KILOGRAM_FORCE` = 9.80665 N.
+  - Pressure → base `PASCAL`: `KILOPASCAL` = 1000 Pa, `BAR` = 100000 Pa, `ATMOSPHERE` = 101325 Pa,
+    `PSI` = 6894.757293168 Pa.
+  - Energy → base `JOULE`: `KILOJOULE` = 1000 J, `CALORIE` = 4.184 J (thermochemical calorie),
+    `KILOCALORIE` = 4184 J, `KILOWATT_HOUR` = 3600000 J, `BTU` = 1055.05585262 J (International Table BTU).
+  - Power → base `WATT`: `KILOWATT` = 1000 W, `MEGAWATT` = 1000000 W, `HORSEPOWER` = 745.699872 W (mechanical/imperial
+    horsepower).
+- **Metric vs. imperial classification** (for each `<X>Unit.getUnitSystem()`), following the same one-imperial-
+  unit-per-family shape already used by `AccelerationUnit` (`FEET_PER_SQUARED_SECOND` imperial, rest metric):
+  - Force: `POUND_FORCE` → `IMPERIAL`; `NEWTON`, `KILONEWTON`, `DYNE`, `KILOGRAM_FORCE` → `METRIC` (default).
+  - Pressure: `PSI` → `IMPERIAL`; `PASCAL`, `KILOPASCAL`, `BAR`, `ATMOSPHERE` → `METRIC` (default).
+  - Energy: `BTU` → `IMPERIAL`; `JOULE`, `KILOJOULE`, `CALORIE`, `KILOCALORIE`, `KILOWATT_HOUR` → `METRIC` (default).
+  - Power: `HORSEPOWER` → `IMPERIAL`; `WATT`, `KILOWATT`, `MEGAWATT` → `METRIC` (default).
+- **Formatter symbols**: `N`, `kN`, `lbf`, `dyn`, `kgf` (Force); `Pa`, `kPa`, `bar`, `atm`, `psi` (Pressure);
+  `J`, `kJ`, `cal`, `kcal`, `kWh`, `BTU` (Energy); `W`, `kW`, `MW`, `hp` (Power) — standard scientific symbols,
+  matching the mixed-case style already used (e.g. `SpeedFormatter`'s `"Km/h"`).
+- **`formatAndConvertMetric`/`formatAndConvertImperial` strategy**: since none of these four families' suggested
+  unit sets form a clean power-of-ten magnitude ladder the way `Weight`'s gram/kilogram/tonne chain does (e.g.
+  `DYNE`, `KILOGRAM_FORCE`, `ATMOSPHERE`, `CALORIE`, `HORSEPOWER` are not decimal multiples of their base unit),
+  each new formatter should follow `AccelerationFormatter`'s simpler approach instead: always format in one
+  fixed canonical unit per system (e.g. `PressureFormatter.formatAndConvertMetric` always converts to and
+  formats as `PASCAL`; `formatAndConvertImperial` always converts to and formats as `PSI`) rather than
+  attempting magnitude-based tier selection.
+- Every measurement class in this codebase (`Frequency`, `Temperature`, `Weight`, `Distance`, `Acceleration`,
+  and `Speed` alike) carries the same `add`/`subtract` convenience API (~22 overloads: static double/Number,
+  in-place `Speed`-style, `addAndReturnNew`, instance mutating/non-mutating variants) — confirmed this is the
+  universal baseline, not something bespoke to `Speed`. The four new measurement classes must include the same
+  API shape.
+
+## Current code state
+
+- All production code lives in `src/main/java/com/irurueta/units/`. 13 measurement families exist today
+  (`Distance`, `Surface`, `Volume`, `Speed`, `Acceleration`, `Angle`, `AngularSpeed`, `AngularAcceleration`,
+  `Time`, `Frequency`, `Temperature`, `Weight`, `MagneticFluxDensity`) — none of `Force`, `Pressure`, `Energy`,
+  `Power` exist yet.
+- Every family follows an identical 4-class shape (studied in depth via `Speed.java` / `SpeedUnit.java` /
+  `SpeedConverter.java` / `SpeedFormatter.java`, cross-checked against `AccelerationFormatter.java` and
+  `WeightFormatter.java` for formatting-strategy variants):
+  - `<X>Unit` — enum with a Javadoc comment per constant; static `getUnitSystem(unit)` (switch expression,
+    `IllegalArgumentException` on null), `getMetricUnits()`/`getImperialUnits()` (hard-coded arrays),
+    `isMetric(unit)`/`isImperial(unit)` (delegate to `getUnitSystem`).
+  - `<X>` — extends `Measurement<XUnit>` (`Measurement.java`); public `(Number value, XUnit unit)` constructor
+    (throws `IllegalArgumentException` on null via the parent), package-private no-arg constructor; overrides
+    `equals(Measurement<XUnit> other, double tolerance)` to add cross-unit tolerant comparison via
+    `<X>Converter.convert(...)`; full `add`/`subtract`/`addAndReturnNew`/`subtractAndReturnNew` overload family.
+  - `<X>Converter` — private no-arg constructor (`HideUtilityClassConstructor`); package-private
+    (not `private`) `static final double` conversion-factor constants at the top with one-line Javadoc each
+    (package-private so the matching `<X>Formatter` can read them directly, as `SpeedFormatter` does with
+    `SpeedConverter.METERS_PER_KILOMETER`); overload set: `convert(double, XUnit, XUnit)` (the actual math, two
+    chained switch expressions through the base unit), `convert(Number, XUnit, XUnit)`,
+    `convert(X input, X output)`, `convert(X input, XUnit outputUnit)`, `convert(X input, XUnit outputUnit, X result)`,
+    `convertAndReturnNew(X input, XUnit outputUnit)`; one named to-base/from-base method pair per non-base unit
+    (e.g. `dyneToNewton`/`newtonToDyne`), each referencing only the named constants, never raw literals.
+  - `<X>Formatter` — extends `MeasureFormatter<X, XUnit>` (`MeasureFormatter.java`); must implement exactly the
+    5 abstract methods: `formatAndConvert(Number, XUnit, UnitSystem)`, `getUnitSystem(String)`,
+    `parse(String)`, `findUnit(String)`, `getUnitSymbol(XUnit)`; unit-symbol `String` constants; 3 constructors
+    (no-arg, `Locale`, copy); `equals`/`hashCode` overrides delegating to `super`; `findUnit` checks
+    longest/most-specific symbols first to avoid substring false-matches.
+- README.md line 171 has the "Supported measurement families" table (2 columns:
+  `| Measurement | Examples of units |`), 11 rows, ending with `MagneticFluxDensity` right before the
+  `## 🤝 Contributing` section at line 187.
+- Checkstyle (`checkstyle.xml`) enables `MagicNumber`, `JavadocVariable`, `JavadocType`, `JavadocMethod`,
+  `HideUtilityClassConstructor`, `ConstantName`, `DeclarationOrder` — all satisfied by mirroring the existing
+  converter/formatter constant-declaration pattern exactly.
+- Tests mirror 1:1 under `src/test/java/com/irurueta/units/`: `<X>UnitTest`, `<X>Test`, `<X>ConverterTest`,
+  `<X>FormatterTest`. `SpeedConverterTest` re-declares conversion constants locally to test independently of the
+  converter's own constants, and includes an exhaustive N×N matrix test (`testConvertDouble`) across every unit
+  pairing. `SpeedFormatterTest`/`WeightFormatterTest` test formatting/parsing per-unit in both a metric locale
+  (`es`,`ES`) and an imperial locale (`en`,`US`).
+- License header convention (Apache 2.0, `Copyright (C) <year> Alberto Irurueta Carro (alberto@irurueta.com)`)
+  must be present on every new file — use `2026` as the year for new files.
+
+## Implementation steps
+
+1. [x] **Add the `Force` measurement family** _(java)_ — `ForceUnit`, `Force`, `ForceConverter`, `ForceFormatter`
+   plus mirrored tests (80 tests, 100% line/branch coverage), README row added. No new Checkstyle/PMD/SpotBugs
+   issues beyond pre-existing repo-wide patterns already present in sibling classes.
+   - [x] Create `src/main/java/com/irurueta/units/ForceUnit.java`: enum constants `NEWTON`, `KILONEWTON`,
+     `POUND_FORCE`, `DYNE`, `KILOGRAM_FORCE`; `getUnitSystem`, `getMetricUnits`, `getImperialUnits`, `isMetric`,
+     `isImperial` statics mirroring `AccelerationUnit`/`SpeedUnit`.
+   - [x] Create `src/main/java/com/irurueta/units/Force.java`: extends `Measurement<ForceUnit>`; constructors;
+     tolerance-based `equals`; full add/subtract API, mirroring `Speed.java`'s shape.
+   - [x] Create `src/main/java/com/irurueta/units/ForceConverter.java`: base unit `NEWTON`; constants
+     `KILONEWTONS_PER_NEWTON`/`NEWTONS_PER_KILONEWTON`-style naming consistent with existing converters (pick
+     the direction that matches how `SpeedConverter` names things, e.g. `NEWTONS_PER_POUND_FORCE`,
+     `NEWTONS_PER_DYNE`, `NEWTONS_PER_KILOGRAM_FORCE`, `NEWTONS_PER_KILONEWTON`) with the values from the Task
+     summary; full convert overload set; to/from-base conversion method pairs (e.g. `poundForceToNewton`/
+     `newtonToPoundForce`, `dyneToNewton`/`newtonToDyne`, `kilogramForceToNewton`/`newtonToKilogramForce`,
+     `kilonewtonToNewton`/`newtonToKilonewton`).
+   - [x] Create `src/main/java/com/irurueta/units/ForceFormatter.java`: extends
+     `MeasureFormatter<Force, ForceUnit>`; symbols `N`, `kN`, `lbf`, `dyn`, `kgf`;
+     `formatAndConvertMetric` always formats as `NEWTON`; `formatAndConvertImperial` always formats as
+     `POUND_FORCE`, mirroring `AccelerationFormatter`.
+   - [x] Create `src/test/java/com/irurueta/units/ForceUnitTest.java` mirroring `SpeedUnitTest`/
+     `AccelerationUnitTest` (per-constant `getUnitSystem`, `getMetricUnits`/`getImperialUnits` completeness
+     check, `isMetric`/`isImperial`, null → `IllegalArgumentException`).
+   - [x] Create `src/test/java/com/irurueta/units/ForceTest.java` mirroring `SpeedTest` (constructor, equals/
+     hashCode/tolerance, add/subtract family, serialization round-trip).
+   - [x] Create `src/test/java/com/irurueta/units/ForceConverterTest.java` mirroring `SpeedConverterTest`
+     (locally re-declared constants, per-unit-pair to/from-base tests, exhaustive N×N `testConvertDouble`
+     matrix across all 5 units, Force-level overload tests).
+   - [x] Create `src/test/java/com/irurueta/units/ForceFormatterTest.java` mirroring `AccelerationFormatterTest`
+     (constructor/clone/equals/hashCode, format overloads per unit in a metric locale, `formatAndConvert`
+     metric/imperial, `getUnitSymbol`, `findUnit`, `parse`, `isValidUnit`/`isValidMeasurement`/`isMetricUnit`/
+     `isImperialUnit`/`getUnitSystem(String)`).
+   - [x] Add a `Force` row to the README.md "Supported measurement families" table (after `MagneticFluxDensity`,
+     before `## 🤝 Contributing`): `| \`Force\` | \`NEWTON\`, \`KILONEWTON\`, \`POUND_FORCE\`, \`DYNE\`,
+     \`KILOGRAM_FORCE\` |`.
+   - [x] Run the tests for this family via `gate-runner`:
+     `Agent({description: "Run Force family tests", subagent_type: "gate-runner", prompt: "Invoke a Maven test
+     run scoped to Force*Test classes (mvn test -Dtest=ForceUnitTest,ForceTest,ForceConverterTest,
+     ForceFormatterTest) in /Users/albertoirurueta/repositories/common/irurueta-units and report pass/fail
+     summary plus any failures."})`.
+
+2. [x] **Add the `Pressure` measurement family** _(java)_ — `PressureUnit`, `Pressure`, `PressureConverter`,
+   `PressureFormatter` plus mirrored tests (80 tests, 100% line/branch coverage), README row added. No new
+   Checkstyle/PMD/SpotBugs issues beyond pre-existing repo-wide patterns already present in the Force family.
+   - [x] Create `src/main/java/com/irurueta/units/PressureUnit.java`: enum constants `PASCAL`, `KILOPASCAL`,
+     `BAR`, `ATMOSPHERE`, `PSI`; same statics shape as Task 1.
+   - [x] Create `src/main/java/com/irurueta/units/Pressure.java`: extends `Measurement<PressureUnit>`; same
+     shape as `Force.java`.
+   - [x] Create `src/main/java/com/irurueta/units/PressureConverter.java`: base unit `PASCAL`; constants
+     `PASCALS_PER_KILOPASCAL` = 1000, `PASCALS_PER_BAR` = 100000, `PASCALS_PER_ATMOSPHERE` = 101325,
+     `PASCALS_PER_PSI` = 6894.757293168; to/from-base method pairs per unit.
+   - [x] Create `src/main/java/com/irurueta/units/PressureFormatter.java`: extends
+     `MeasureFormatter<Pressure, PressureUnit>`; symbols `Pa`, `kPa`, `bar`, `atm`, `psi`;
+     `formatAndConvertMetric` always formats as `PASCAL`; `formatAndConvertImperial` always formats as `PSI`.
+   - [x] Create `src/test/java/com/irurueta/units/PressureUnitTest.java` mirroring Task 1's unit test.
+   - [x] Create `src/test/java/com/irurueta/units/PressureTest.java` mirroring Task 1's measurement test.
+   - [x] Create `src/test/java/com/irurueta/units/PressureConverterTest.java` mirroring Task 1's converter test
+     (N×N matrix across all 5 units).
+   - [x] Create `src/test/java/com/irurueta/units/PressureFormatterTest.java` mirroring Task 1's formatter test.
+   - [x] Add a `Pressure` row to the README.md table: `| \`Pressure\` | \`PASCAL\`, \`KILOPASCAL\`, \`BAR\`,
+     \`ATMOSPHERE\`, \`PSI\` |`.
+   - [x] Run the tests for this family via `gate-runner`:
+     `Agent({description: "Run Pressure family tests", subagent_type: "gate-runner", prompt: "Invoke a Maven
+     test run scoped to Pressure*Test classes (mvn test -Dtest=PressureUnitTest,PressureTest,
+     PressureConverterTest,PressureFormatterTest) in /Users/albertoirurueta/repositories/common/irurueta-units
+     and report pass/fail summary plus any failures."})`.
+
+3. [x] **Add the `Energy` measurement family** _(java)_ — `EnergyUnit`, `Energy`, `EnergyConverter`,
+   `EnergyFormatter` plus mirrored tests (81 tests, 100% line/branch coverage), README row added,
+   `package-info.java` summary extended. No new Checkstyle/PMD/SpotBugs issues beyond pre-existing repo-wide
+   patterns already present in the Force/Pressure families.
+   - [x] Create `src/main/java/com/irurueta/units/EnergyUnit.java`: enum constants `JOULE`, `KILOJOULE`,
+     `CALORIE`, `KILOCALORIE`, `KILOWATT_HOUR`, `BTU`; same statics shape as Task 1.
+   - [x] Create `src/main/java/com/irurueta/units/Energy.java`: extends `Measurement<EnergyUnit>`; same shape
+     as `Force.java`.
+   - [x] Create `src/main/java/com/irurueta/units/EnergyConverter.java`: base unit `JOULE`; constants
+     `JOULES_PER_KILOJOULE` = 1000, `JOULES_PER_CALORIE` = 4.184, `JOULES_PER_KILOCALORIE` = 4184,
+     `JOULES_PER_KILOWATT_HOUR` = 3600000, `JOULES_PER_BTU` = 1055.05585262; to/from-base method pairs per unit.
+   - [x] Create `src/main/java/com/irurueta/units/EnergyFormatter.java`: extends
+     `MeasureFormatter<Energy, EnergyUnit>`; symbols `J`, `kJ`, `cal`, `kcal`, `kWh`, `BTU`;
+     `formatAndConvertMetric` always formats as `JOULE`; `formatAndConvertImperial` always formats as `BTU`.
+   - [x] Create `src/test/java/com/irurueta/units/EnergyUnitTest.java` mirroring Task 1's unit test.
+   - [x] Create `src/test/java/com/irurueta/units/EnergyTest.java` mirroring Task 1's measurement test.
+   - [x] Create `src/test/java/com/irurueta/units/EnergyConverterTest.java` mirroring Task 1's converter test
+     (N×N matrix across all 6 units).
+   - [x] Create `src/test/java/com/irurueta/units/EnergyFormatterTest.java` mirroring Task 1's formatter test.
+   - [x] Add an `Energy` row to the README.md table: `| \`Energy\` | \`JOULE\`, \`KILOJOULE\`, \`CALORIE\`,
+     \`KILOCALORIE\`, \`KILOWATT_HOUR\`, \`BTU\` |`.
+   - [x] Run the tests for this family via `gate-runner`:
+     `Agent({description: "Run Energy family tests", subagent_type: "gate-runner", prompt: "Invoke a Maven test
+     run scoped to Energy*Test classes (mvn test -Dtest=EnergyUnitTest,EnergyTest,EnergyConverterTest,
+     EnergyFormatterTest) in /Users/albertoirurueta/repositories/common/irurueta-units and report pass/fail
+     summary plus any failures."})`.
+
+4. [x] **Add the `Power` measurement family** _(java)_ — `PowerUnit`, `Power`, `PowerConverter`,
+   `PowerFormatter` plus mirrored tests (79 tests, 100% line coverage on all 4 classes verified independently
+   via jacoco), README row added. No new SpotBugs issues; +1 PMD `UselessOverridingMethod`
+   (`PowerFormatter.hashCode`) and additional Checkstyle `LineLength`/`MagicNumber`-family findings, both being
+   exact instances of the same pre-existing repo-wide pattern already present in the Force/Pressure/Energy
+   formatters/converters mirrored by this task.
+   - [x] Create `src/main/java/com/irurueta/units/PowerUnit.java`: enum constants `WATT`, `KILOWATT`,
+     `MEGAWATT`, `HORSEPOWER`; same statics shape as Task 1.
+   - [x] Create `src/main/java/com/irurueta/units/Power.java`: extends `Measurement<PowerUnit>`; same shape as
+     `Force.java`.
+   - [x] Create `src/main/java/com/irurueta/units/PowerConverter.java`: base unit `WATT`; constants
+     `WATTS_PER_KILOWATT` = 1000, `WATTS_PER_MEGAWATT` = 1000000, `WATTS_PER_HORSEPOWER` = 745.699872; to/from-
+     base method pairs per unit.
+   - [x] Create `src/main/java/com/irurueta/units/PowerFormatter.java`: extends
+     `MeasureFormatter<Power, PowerUnit>`; symbols `W`, `kW`, `MW`, `hp`; `formatAndConvertMetric` always
+     formats as `WATT`; `formatAndConvertImperial` always formats as `HORSEPOWER`.
+   - [x] Create `src/test/java/com/irurueta/units/PowerUnitTest.java` mirroring Task 1's unit test.
+   - [x] Create `src/test/java/com/irurueta/units/PowerTest.java` mirroring Task 1's measurement test.
+   - [x] Create `src/test/java/com/irurueta/units/PowerConverterTest.java` mirroring Task 1's converter test
+     (N×N matrix across all 4 units).
+   - [x] Create `src/test/java/com/irurueta/units/PowerFormatterTest.java` mirroring Task 1's formatter test.
+   - [x] Add a `Power` row to the README.md table: `| \`Power\` | \`WATT\`, \`KILOWATT\`, \`MEGAWATT\`,
+     \`HORSEPOWER\` |`.
+   - [x] Run the tests for this family via `gate-runner`:
+     `Agent({description: "Run Power family tests", subagent_type: "gate-runner", prompt: "Invoke a Maven test
+     run scoped to Power*Test classes (mvn test -Dtest=PowerUnitTest,PowerTest,PowerConverterTest,
+     PowerFormatterTest) in /Users/albertoirurueta/repositories/common/irurueta-units and report pass/fail
+     summary plus any failures."})`.
+
+5. [x] **Full-suite verification and quality gates** _(java)_ — full suite green (1373/1373 tests). Checkstyle
+   1218 issues (up from a 1032 pre-existing baseline) and PMD 19 issues (up from 15) — the entire delta is
+   attributable to the 4 new families mirroring the same repo-wide LineLength/MagicNumber/UselessOverridingMethod
+   patterns already present in every sibling class, as each per-family task noted; SpotBugs unchanged at 3
+   (identical pre-existing findings, none in new code). README confirmed with all 4 new rows, no formatting
+   regressions. Per the `code` skill's Step 7 gate, this net increase is flagged to the user for a decision
+   (fix now / file follow-up issues / accept as-is) rather than silently proceeding — see the final summary.
+   - [x] Run the complete test suite via `gate-runner`: `Agent({description: "Run full test suite",
+     subagent_type: "gate-runner", prompt: "Invoke `mvn test` in
+     /Users/albertoirurueta/repositories/common/irurueta-units and report pass/fail summary, total test count,
+     and any failures."})` — confirms no regressions in the other 13 families. Result: 1373 tests, 0
+     failures/errors/skipped.
+   - [x] Run Checkstyle via `gate-runner`: `Agent({description: "Run checkstyle", subagent_type: "gate-runner",
+     prompt: "Invoke `mvn checkstyle:check` in /Users/albertoirurueta/repositories/common/irurueta-units and
+     report violations, if any, with file/line."})`. Result: 1218 violations across 58 files (baseline: 1032).
+   - [x] Run SpotBugs via `gate-runner`: `Agent({description: "Run spotbugs", subagent_type: "gate-runner",
+     prompt: "Invoke `mvn com.github.spotbugs:spotbugs-maven-plugin:check` in
+     /Users/albertoirurueta/repositories/common/irurueta-units and report violations, if any."})`. Result: 3
+     violations (MeasureFormatter x2, Measurement x1) — identical to baseline, no new findings.
+   - [x] Confirm the README.md table now has all four new rows (`Force`, `Pressure`, `Energy`, `Power`) in
+     addition to the original 11, with no formatting regressions to the surrounding sections. Confirmed: lines
+     186-189 of README.md.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ npx antora antora-playbook.yml
 | `Frequency` | `HERTZ`, `KILOHERTZ`, `MEGAHERTZ`, `GIGAHERTZ` |
 | `Angle` and angular motion | `RADIANS`, `RADIANS_PER_SECOND`, `RADIANS_PER_SQUARED_SECOND` |
 | `MagneticFluxDensity` | `NANOTESLA`, `MICROTESLA`, `MILLITESLA`, `TESLA` |
+| `Force` | `NEWTON`, `KILONEWTON`, `POUND_FORCE`, `DYNE`, `KILOGRAM_FORCE` |
+| `Pressure` | `PASCAL`, `KILOPASCAL`, `BAR`, `ATMOSPHERE`, `PSI` |
+| `Energy` | `JOULE`, `KILOJOULE`, `CALORIE`, `KILOCALORIE`, `KILOWATT_HOUR`, `BTU` |
+| `Power` | `WATT`, `KILOWATT`, `MEGAWATT`, `HORSEPOWER` |
 
 ## 🤝 Contributing
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,7 +4,7 @@
 NOTE: This documentation was generated with the assistance of AI. Please report any inaccuracies.
 
 Irurueta Units is a lightweight Java library for working with physical measurements.
-It provides type-specific value objects such as `Distance`, `Speed`, `Temperature`, `Time`, and `Weight`; unit enumerations such as `DistanceUnit` and `TemperatureUnit`; converter utilities; and locale-aware formatters.
+It provides type-specific value objects such as `Distance`, `Speed`, `Temperature`, `Time`, `Weight`, `Force`, `Pressure`, `Energy`, and `Power`; unit enumerations such as `DistanceUnit` and `TemperatureUnit`; converter utilities; and locale-aware formatters.
 
 The library is useful when an application needs to keep a numeric value together with its unit, convert between metric and imperial representations, parse user-entered measurements, or display values using symbols that users expect.
 
@@ -34,7 +34,7 @@ graph TD
 
 `Measurement`::
 Base class for a numeric value and an enum unit.
-Concrete measurements include `Distance`, `Surface`, `Volume`, `Speed`, `Acceleration`, `Angle`, `AngularSpeed`, `AngularAcceleration`, `Time`, `Frequency`, `Temperature`, `Weight`, and `MagneticFluxDensity`.
+Concrete measurements include `Distance`, `Surface`, `Volume`, `Speed`, `Acceleration`, `Angle`, `AngularSpeed`, `AngularAcceleration`, `Time`, `Frequency`, `Temperature`, `Weight`, `MagneticFluxDensity`, `Force`, `Pressure`, `Energy`, and `Power`.
 
 `*Unit`::
 Enum types that list the units supported for each measurement family.

--- a/docs/modules/ROOT/pages/supported-units.adoc
+++ b/docs/modules/ROOT/pages/supported-units.adoc
@@ -29,6 +29,14 @@ The following table lists the concrete measurement classes and their unit enums.
 | `DistanceUnit`
 | `MILLIMETER`, `CENTIMETER`, `METER`, `KILOMETER`, `INCH`, `FOOT`, `YARD`, `MILE`
 
+| `Energy`
+| `EnergyUnit`
+| `JOULE`, `KILOJOULE`, `CALORIE`, `KILOCALORIE`, `KILOWATT_HOUR`, `BTU`
+
+| `Force`
+| `ForceUnit`
+| `NEWTON`, `KILONEWTON`, `POUND_FORCE`, `DYNE`, `KILOGRAM_FORCE`
+
 | `Frequency`
 | `FrequencyUnit`
 | `HERTZ`, `KILOHERTZ`, `MEGAHERTZ`, `GIGAHERTZ`
@@ -36,6 +44,14 @@ The following table lists the concrete measurement classes and their unit enums.
 | `MagneticFluxDensity`
 | `MagneticFluxDensityUnit`
 | `NANOTESLA`, `MICROTESLA`, `MILLITESLA`, `TESLA`, `KILOTESLA`, `MEGATESLA`
+
+| `Power`
+| `PowerUnit`
+| `WATT`, `KILOWATT`, `MEGAWATT`, `HORSEPOWER`
+
+| `Pressure`
+| `PressureUnit`
+| `PASCAL`, `KILOPASCAL`, `BAR`, `ATMOSPHERE`, `PSI`
 
 | `Speed`
 | `SpeedUnit`
@@ -79,4 +95,4 @@ DistanceUnit[] metricDistanceUnits = DistanceUnit.getMetricUnits();
 DistanceUnit[] imperialDistanceUnits = DistanceUnit.getImperialUnits();
 ----
 
-These helpers are available on families where the distinction applies, such as distance, speed, surface, volume, weight, acceleration, and temperature.
+These helpers are available on families where the distinction applies, such as distance, speed, surface, volume, weight, acceleration, temperature, force, pressure, energy, and power.

--- a/src/main/java/com/irurueta/units/Energy.java
+++ b/src/main/java/com/irurueta/units/Energy.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.math.BigDecimal;
+
+/**
+ * Contains an energy value and unit.
+ */
+@SuppressWarnings("WeakerAccess")
+public class Energy extends Measurement<EnergyUnit> {
+
+    /**
+     * Constructor with value and unit.
+     *
+     * @param value energy value.
+     * @param unit  unit of energy.
+     * @throws IllegalArgumentException if either value or unit is null.
+     */
+    public Energy(final Number value, final EnergyUnit unit) {
+        super(value, unit);
+    }
+
+    /**
+     * Constructor.
+     */
+    Energy() {
+        super();
+    }
+
+    /**
+     * Determines if two energies are equal up to a certain tolerance.
+     * If needed, this method attempts unit conversion to compare both objects.
+     *
+     * @param other     another energy to compare.
+     * @param tolerance amount of tolerance to determine whether two energy instances are equal or not.
+     * @return true if provided energy is assumed to be equal to this instance,
+     * false otherwise.
+     */
+    @Override
+    public boolean equals(final Measurement<EnergyUnit> other, final double tolerance) {
+        if (super.equals(other, tolerance)) {
+            return true;
+        }
+
+        //attempt conversion to common units
+        if (other == null) {
+            return false;
+        }
+
+        final var otherValue = EnergyConverter.convert(
+                other.getValue().doubleValue(), other.getUnit(), getUnit());
+        return Math.abs(getValue().doubleValue() - otherValue) <= tolerance;
+    }
+
+    /**
+     * Adds two energy values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of addition.
+     */
+    public static double add(final double value1, final EnergyUnit unit1,
+                             final double value2, final EnergyUnit unit2,
+                             final EnergyUnit resultUnit) {
+        final var v1 = EnergyConverter.convert(value1, unit1, resultUnit);
+        final var v2 = EnergyConverter.convert(value2, unit2, resultUnit);
+        return v1 + v2;
+    }
+
+    /**
+     * Adds two energy values and unit and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of addition.
+     */
+    public static Number add(final Number value1, final EnergyUnit unit1,
+                             final Number value2, final EnergyUnit unit2,
+                             final EnergyUnit resultUnit) {
+        return BigDecimal.valueOf(add(value1.doubleValue(), unit1, value2.doubleValue(), unit2, resultUnit));
+    }
+
+    /**
+     * Adds two energy instances and stores the result into provided instance.
+     *
+     * @param arg1   1st argument.
+     * @param arg2   2nd argument.
+     * @param result instance where result will be stored.
+     */
+    public static void add(final Energy arg1, final Energy arg2, final Energy result) {
+        result.setValue(add(arg1.getValue(), arg1.getUnit(), arg2.getValue(), arg2.getUnit(), result.getUnit()));
+    }
+
+    /**
+     * Adds two energy instances.
+     *
+     * @param arg1 1st argument.
+     * @param arg2 2nd argument.
+     * @param unit unit of returned energy.
+     * @return a new instance containing result.
+     */
+    public static Energy addAndReturnNew(final Energy arg1, final Energy arg2, final EnergyUnit unit) {
+        final var result = new Energy();
+        result.setUnit(unit);
+        add(arg1, arg2, result);
+        return result;
+    }
+
+    /**
+     * Adds provided energy value and unit and returns a new energy instance using
+     * provided unit.
+     *
+     * @param value      value to be added.
+     * @param unit       unit of value to be added.
+     * @param resultUnit unit of returned energy.
+     * @return a new energy containing result.
+     */
+    public Energy addAndReturnNew(
+            final double value, final EnergyUnit unit, final EnergyUnit resultUnit) {
+        final var result = new Energy();
+        result.setUnit(resultUnit);
+        result.setValue(add(getValue().doubleValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Adds provided energy value and unit and returns a new energy instance using
+     * provided unit.
+     *
+     * @param value      value to be added.
+     * @param unit       unit of value to be added.
+     * @param resultUnit unit of returned energy.
+     * @return a new energy containing result.
+     */
+    public Energy addAndReturnNew(
+            final Number value, final EnergyUnit unit, final EnergyUnit resultUnit) {
+        final var result = new Energy();
+        result.setUnit(resultUnit);
+        result.setValue(add(getValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Adds provided energy to current instance and returns a new energy.
+     *
+     * @param e    energy to be added.
+     * @param unit unit of returned energy.
+     * @return a new energy containing result.
+     */
+    public Energy addAndReturnNew(final Energy e, final EnergyUnit unit) {
+        return addAndReturnNew(this, e, unit);
+    }
+
+    /**
+     * Adds provided energy value and unit and updates current energy instance.
+     *
+     * @param value energy value to be added.
+     * @param unit  unit of energy value.
+     */
+    public void add(final double value, final EnergyUnit unit) {
+        setValue(add(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Adds provided energy value and unit and updates current energy instance.
+     *
+     * @param value energy value to be added.
+     * @param unit  unit of energy value.
+     */
+    public void add(final Number value, final EnergyUnit unit) {
+        setValue(add(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Adds provided energy and updates current energy.
+     *
+     * @param energy energy to be added.
+     */
+    public void add(final Energy energy) {
+        add(this, energy, this);
+    }
+
+    /**
+     * Adds provided energy and stores the result into provided energy.
+     *
+     * @param e      energy to be added.
+     * @param result instance where result will be stored.
+     */
+    public void add(final Energy e, final Energy result) {
+        add(this, e, result);
+    }
+
+    /**
+     * Subtracts two energy values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of subtraction.
+     */
+    public static double subtract(
+            final double value1, final EnergyUnit unit1,
+            final double value2, final EnergyUnit unit2,
+            final EnergyUnit resultUnit) {
+        final var v1 = EnergyConverter.convert(value1, unit1, resultUnit);
+        final var v2 = EnergyConverter.convert(value2, unit2, resultUnit);
+        return v1 - v2;
+    }
+
+    /**
+     * Subtracts two energy values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of subtraction.
+     */
+    public static Number subtract(
+            final Number value1, final EnergyUnit unit1,
+            final Number value2, final EnergyUnit unit2,
+            final EnergyUnit resultUnit) {
+        return BigDecimal.valueOf(subtract(value1.doubleValue(), unit1, value2.doubleValue(), unit2, resultUnit));
+    }
+
+    /**
+     * Subtracts two energy instances and stores the result into provided instance.
+     *
+     * @param arg1   1st argument.
+     * @param arg2   2nd argument.
+     * @param result instance where result will be stored.
+     */
+    public static void subtract(final Energy arg1, final Energy arg2, final Energy result) {
+        result.setValue(subtract(
+                arg1.getValue(), arg1.getUnit(), arg2.getValue(), arg2.getUnit(), result.getUnit()));
+    }
+
+    /**
+     * Subtracts two energy instances.
+     *
+     * @param arg1 1st argument.
+     * @param arg2 2nd argument.
+     * @param unit unit of returned energy.
+     * @return a new instance containing result.
+     */
+    public static Energy subtractAndReturnNew(
+            final Energy arg1, final Energy arg2, final EnergyUnit unit) {
+        final var result = new Energy();
+        result.setUnit(unit);
+        subtract(arg1, arg2, result);
+        return result;
+    }
+
+    /**
+     * Subtracts provided energy value and unit and returns a nw energy instance using
+     * provided unit.
+     *
+     * @param value      value to be subtracted.
+     * @param unit       unit of value to be subtracted.
+     * @param resultUnit unit of returned energy.
+     * @return a new energy containing result.
+     */
+    public Energy subtractAndReturnNew(
+            final double value, final EnergyUnit unit, final EnergyUnit resultUnit) {
+        final var result = new Energy();
+        result.setUnit(resultUnit);
+        result.setValue(subtract(getValue().doubleValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Subtracts provided energy value and unit and returns a new energy instance using
+     * provided unit.
+     *
+     * @param value      value to be subtracted.
+     * @param unit       unit of value to be subtracted.
+     * @param resultUnit unit of returned energy.
+     * @return a new energy containing result.
+     */
+    public Energy subtractAndReturnNew(
+            final Number value, final EnergyUnit unit, final EnergyUnit resultUnit) {
+        final var result = new Energy();
+        result.setUnit(resultUnit);
+        result.setValue(subtract(getValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Subtracts provided energy to current instance and returns a new energy instance.
+     *
+     * @param e    energy to be subtracted.
+     * @param unit unit of returned energy.
+     * @return a new energy containing result.
+     */
+    public Energy subtractAndReturnNew(final Energy e, final EnergyUnit unit) {
+        return subtractAndReturnNew(this, e, unit);
+    }
+
+    /**
+     * Subtracts provided energy value and unit and updates current energy instance.
+     *
+     * @param value energy value to be subtracted.
+     * @param unit  unit of energy value.
+     */
+    public void subtract(final double value, final EnergyUnit unit) {
+        setValue(subtract(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Subtracts provided energy value and unit and updates current energy instance.
+     *
+     * @param value energy value to be subtracted.
+     * @param unit  unit of energy value.
+     */
+    public void subtract(final Number value, final EnergyUnit unit) {
+        setValue(subtract(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Subtracts provided energy and updates current energy.
+     *
+     * @param energy energy to be subtracted.
+     */
+    public void subtract(final Energy energy) {
+        subtract(this, energy, this);
+    }
+
+    /**
+     * Subtracts provided energy and stores the result into provided energy.
+     *
+     * @param e      energy to be subtracted.
+     * @param result instance where result will be stored.
+     */
+    public void subtract(final Energy e, final Energy result) {
+        subtract(this, e, result);
+    }
+}

--- a/src/main/java/com/irurueta/units/EnergyConverter.java
+++ b/src/main/java/com/irurueta/units/EnergyConverter.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.math.BigDecimal;
+
+/**
+ * Does energy conversions to different units.
+ * To prevent loss of accuracy, conversion should only be done as a final step
+ * before displaying energy measurements.
+ */
+@SuppressWarnings("WeakerAccess")
+public class EnergyConverter {
+
+    /**
+     * Number of joules in 1 kilojoule.
+     */
+    static final double JOULES_PER_KILOJOULE = 1000.0;
+
+    /**
+     * Number of joules in 1 calorie.
+     */
+    static final double JOULES_PER_CALORIE = 4.184;
+
+    /**
+     * Number of joules in 1 kilocalorie.
+     */
+    static final double JOULES_PER_KILOCALORIE = 4184.0;
+
+    /**
+     * Number of joules in 1 kilowatt-hour.
+     */
+    static final double JOULES_PER_KILOWATT_HOUR = 3600000.0;
+
+    /**
+     * Number of joules in 1 BTU.
+     */
+    static final double JOULES_PER_BTU = 1055.05585262;
+
+    /**
+     * Constructor.
+     * Prevents instantiation of helper class.
+     */
+    private EnergyConverter() {
+    }
+
+    /**
+     * Converts an energy instance to provided output energy unit.
+     *
+     * @param input  input energy to be converted.
+     * @param output output energy where result will be stored containing output unit.
+     */
+    public static void convert(final Energy input, final Energy output) {
+        convert(input, output.getUnit(), output);
+    }
+
+    /**
+     * Converts an energy instance to requested output unit.
+     *
+     * @param input      input energy to be converted.
+     * @param outputUnit requested output unit.
+     * @return converted energy.
+     */
+    public static Energy convertAndReturnNew(
+            final Energy input, final EnergyUnit outputUnit) {
+        final var result = new Energy();
+        convert(input, outputUnit, result);
+        return result;
+    }
+
+    /**
+     * Converts and updates an energy to requested output unit.
+     *
+     * @param energy     input energy to be converted and updated.
+     * @param outputUnit requested output unit.
+     */
+    public static void convert(final Energy energy, final EnergyUnit outputUnit) {
+        convert(energy, outputUnit, energy);
+    }
+
+    /**
+     * Converts an energy to requested output unit.
+     *
+     * @param input      input energy to be converted.
+     * @param outputUnit requested output unit.
+     * @param result     energy instance where result will be stored.
+     */
+    public static void convert(
+            final Energy input, final EnergyUnit outputUnit, final Energy result) {
+        final var value = convert(input.getValue(), input.getUnit(), outputUnit);
+        result.setValue(value);
+        result.setUnit(outputUnit);
+    }
+
+    /**
+     * Converts an energy value from input unit to provided output unit.
+     *
+     * @param input      energy value.
+     * @param inputUnit  input energy unit.
+     * @param outputUnit output energy unit.
+     * @return converted energy value.
+     */
+    public static Number convert(final Number input, final EnergyUnit inputUnit, final EnergyUnit outputUnit) {
+        return BigDecimal.valueOf(convert(input.doubleValue(), inputUnit, outputUnit));
+    }
+
+    /**
+     * Converts an energy value from input unit to provided output unit.
+     *
+     * @param input      energy value.
+     * @param inputUnit  input energy unit.
+     * @param outputUnit output energy unit.
+     * @return converted energy value.
+     */
+    public static double convert(final double input, final EnergyUnit inputUnit, final EnergyUnit outputUnit) {
+        //convert to joules
+        final var joules = switch (inputUnit) {
+            case KILOJOULE -> kilojouleToJoule(input);
+            case CALORIE -> calorieToJoule(input);
+            case KILOCALORIE -> kilocalorieToJoule(input);
+            case KILOWATT_HOUR -> kilowattHourToJoule(input);
+            case BTU -> btuToJoule(input);
+            default -> input;
+        };
+
+        //convert from joules to required output unit
+        return switch (outputUnit) {
+            case KILOJOULE -> jouleToKilojoule(joules);
+            case CALORIE -> jouleToCalorie(joules);
+            case KILOCALORIE -> jouleToKilocalorie(joules);
+            case KILOWATT_HOUR -> jouleToKilowattHour(joules);
+            case BTU -> jouleToBtu(joules);
+            default -> joules;
+        };
+    }
+
+    /**
+     * Converts provided kilojoule value to joules.
+     *
+     * @param kilojoule kilojoule value.
+     * @return same energy converted to joules.
+     */
+    public static double kilojouleToJoule(final double kilojoule) {
+        return kilojoule * JOULES_PER_KILOJOULE;
+    }
+
+    /**
+     * Converts provided joule value to kilojoule.
+     *
+     * @param joule joule value.
+     * @return same energy converted to kilojoule.
+     */
+    public static double jouleToKilojoule(final double joule) {
+        return joule / JOULES_PER_KILOJOULE;
+    }
+
+    /**
+     * Converts provided calorie value to joules.
+     *
+     * @param calorie calorie value.
+     * @return same energy converted to joules.
+     */
+    public static double calorieToJoule(final double calorie) {
+        return calorie * JOULES_PER_CALORIE;
+    }
+
+    /**
+     * Converts provided joule value to calorie.
+     *
+     * @param joule joule value.
+     * @return same energy converted to calorie.
+     */
+    public static double jouleToCalorie(final double joule) {
+        return joule / JOULES_PER_CALORIE;
+    }
+
+    /**
+     * Converts provided kilocalorie value to joules.
+     *
+     * @param kilocalorie kilocalorie value.
+     * @return same energy converted to joules.
+     */
+    public static double kilocalorieToJoule(final double kilocalorie) {
+        return kilocalorie * JOULES_PER_KILOCALORIE;
+    }
+
+    /**
+     * Converts provided joule value to kilocalorie.
+     *
+     * @param joule joule value.
+     * @return same energy converted to kilocalorie.
+     */
+    public static double jouleToKilocalorie(final double joule) {
+        return joule / JOULES_PER_KILOCALORIE;
+    }
+
+    /**
+     * Converts provided kilowatt-hour value to joules.
+     *
+     * @param kilowattHour kilowatt-hour value.
+     * @return same energy converted to joules.
+     */
+    public static double kilowattHourToJoule(final double kilowattHour) {
+        return kilowattHour * JOULES_PER_KILOWATT_HOUR;
+    }
+
+    /**
+     * Converts provided joule value to kilowatt-hour.
+     *
+     * @param joule joule value.
+     * @return same energy converted to kilowatt-hour.
+     */
+    public static double jouleToKilowattHour(final double joule) {
+        return joule / JOULES_PER_KILOWATT_HOUR;
+    }
+
+    /**
+     * Converts provided BTU value to joules.
+     *
+     * @param btu BTU value.
+     * @return same energy converted to joules.
+     */
+    public static double btuToJoule(final double btu) {
+        return btu * JOULES_PER_BTU;
+    }
+
+    /**
+     * Converts provided joule value to BTU.
+     *
+     * @param joule joule value.
+     * @return same energy converted to BTU.
+     */
+    public static double jouleToBtu(final double joule) {
+        return joule / JOULES_PER_BTU;
+    }
+}

--- a/src/main/java/com/irurueta/units/EnergyFormatter.java
+++ b/src/main/java/com/irurueta/units/EnergyFormatter.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.text.ParseException;
+import java.util.Locale;
+
+/**
+ * Formats and parses energy value and unit.
+ */
+public class EnergyFormatter extends MeasureFormatter<Energy, EnergyUnit> {
+
+    /**
+     * Joule symbol.
+     */
+    public static final String JOULE = "J";
+
+    /**
+     * Kilojoule symbol.
+     */
+    public static final String KILOJOULE = "kJ";
+
+    /**
+     * Calorie symbol.
+     */
+    public static final String CALORIE = "cal";
+
+    /**
+     * Kilocalorie symbol.
+     */
+    public static final String KILOCALORIE = "kcal";
+
+    /**
+     * Kilowatt-hour symbol.
+     */
+    public static final String KILOWATT_HOUR = "kWh";
+
+    /**
+     * BTU symbol.
+     */
+    public static final String BTU = "BTU";
+
+    /**
+     * Constructor.
+     */
+    public EnergyFormatter() {
+        super();
+    }
+
+    /**
+     * Constructor with locale.
+     *
+     * @param locale locale.
+     * @throws IllegalArgumentException if locale is null.
+     */
+    public EnergyFormatter(final Locale locale) {
+        super(locale);
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param formatter input instance to copy from.
+     * @throws NullPointerException if provided formatter is null.
+     */
+    public EnergyFormatter(final EnergyFormatter formatter) {
+        this(formatter.getLocale());
+    }
+
+    /**
+     * Determines if two energy formatters are equal by comparing all of their internal
+     * parameters.
+     *
+     * @param obj another object to compare.
+     * @return true if provided object is assumed to be equal to this instance.
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        final var equals = super.equals(obj);
+        return (obj instanceof EnergyFormatter) && equals;
+    }
+
+    /**
+     * Hash code generated for this instance.
+     * Hash codes can be internally used by some collections to coarsely compare objects.
+     * This implementation only calls parent implementation to avoid static analyzer warning.
+     *
+     * @return hash code.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * Gets unit system for detected unit into provided string representation
+     * of a measurement.
+     *
+     * @param source a measurement string representation to be checked.
+     * @return a unit system (either metric or imperial) or null if unit
+     * cannot be determined.
+     */
+    @Override
+    public UnitSystem getUnitSystem(final String source) {
+        final var unit = findUnit(source);
+        return unit != null ? EnergyUnit.getUnitSystem(unit) : null;
+    }
+
+    /**
+     * Parses provided string and tries to determine energy value and unit.
+     *
+     * @param source a string to be parsed.
+     * @return an energy containing a value and unit.
+     * @throws ParseException       if provided string cannot be parsed.
+     * @throws UnknownUnitException if unit cannot be determined.
+     */
+    @Override
+    public Energy parse(final String source) throws ParseException, UnknownUnitException {
+        return internalParse(source, new Energy());
+    }
+
+    /**
+     * Attempts to determine an energy unit within a measurement string representation.
+     *
+     * @param source a measurement string representation.
+     * @return an energy unit, or null if none can be determined.
+     */
+    @Override
+    public EnergyUnit findUnit(final String source) {
+        if (source.contains(KILOWATT_HOUR + " ") || source.endsWith(KILOWATT_HOUR)) {
+            return EnergyUnit.KILOWATT_HOUR;
+        }
+        if (source.contains(BTU + " ") || source.endsWith(BTU)) {
+            return EnergyUnit.BTU;
+        }
+        if (source.contains(KILOCALORIE + " ") || source.endsWith(KILOCALORIE)) {
+            return EnergyUnit.KILOCALORIE;
+        }
+        if (source.contains(KILOJOULE + " ") || source.endsWith(KILOJOULE)) {
+            return EnergyUnit.KILOJOULE;
+        }
+        if (source.contains(CALORIE + " ") || source.endsWith(CALORIE)) {
+            return EnergyUnit.CALORIE;
+        }
+        if (source.contains(JOULE + " ") || source.endsWith(JOULE)) {
+            return EnergyUnit.JOULE;
+        }
+        return null;
+    }
+
+    /**
+     * Formats and converts provided energy value and unit using provided
+     * unit system.
+     * If provided value is too large for provided unit, this method will
+     * convert it to a more appropriate unit using provided unit system (either
+     * metric or imperial).
+     *
+     * @param value  an energy value.
+     * @param unit   an energy unit.
+     * @param system system unit to convert energy to.
+     * @return a string representation of energy value and unit.
+     */
+    @Override
+    public String formatAndConvert(final Number value, final EnergyUnit unit, final UnitSystem system) {
+        if (system == UnitSystem.IMPERIAL) {
+            return formatAndConvertImperial(value, unit);
+        } else {
+            return formatAndConvertMetric(value, unit);
+        }
+    }
+
+    /**
+     * Formats and converts provided energy value and unit using metric unit system.
+     *
+     * @param value an energy value.
+     * @param unit  an energy unit.
+     * @return a string representation of energy value and unit using metric unit system.
+     */
+    public String formatAndConvertMetric(final Number value, final EnergyUnit unit) {
+        //always format as joules
+        return format(EnergyConverter.convert(value, unit, EnergyUnit.JOULE), EnergyUnit.JOULE);
+    }
+
+    /**
+     * Formats and converts provided energy value and unit using imperial unit system.
+     *
+     * @param value an energy value.
+     * @param unit  an energy unit.
+     * @return a string representation of energy value and unit using imperial unit system.
+     */
+    public String formatAndConvertImperial(final Number value, final EnergyUnit unit) {
+        //always format as BTU
+        return format(EnergyConverter.convert(value, unit, EnergyUnit.BTU), EnergyUnit.BTU);
+    }
+
+    /**
+     * Returns unit string representation.
+     *
+     * @param unit an energy unit.
+     * @return its string representation.
+     */
+    @Override
+    public String getUnitSymbol(final EnergyUnit unit) {
+        return switch (unit) {
+            case KILOJOULE -> KILOJOULE;
+            case CALORIE -> CALORIE;
+            case KILOCALORIE -> KILOCALORIE;
+            case KILOWATT_HOUR -> KILOWATT_HOUR;
+            case BTU -> BTU;
+            default -> JOULE;
+        };
+    }
+}

--- a/src/main/java/com/irurueta/units/EnergyUnit.java
+++ b/src/main/java/com/irurueta/units/EnergyUnit.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+/**
+ * Enumerator containing recognized typical energy units.
+ */
+public enum EnergyUnit {
+    /**
+     * Joule (J).
+     */
+    JOULE,
+
+    /**
+     * Kilojoule (kJ).
+     */
+    KILOJOULE,
+
+    /**
+     * Calorie (cal).
+     */
+    CALORIE,
+
+    /**
+     * Kilocalorie (kcal).
+     */
+    KILOCALORIE,
+
+    /**
+     * Kilowatt-hour (kWh).
+     */
+    KILOWATT_HOUR,
+
+    /**
+     * British thermal unit (BTU).
+     */
+    BTU;
+
+    /**
+     * Returns unit system for provided energy unit.
+     *
+     * @param unit energy unit to be checked.
+     * @return unit system (metric or imperial).
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static UnitSystem getUnitSystem(final EnergyUnit unit) {
+        if (unit == null) {
+            throw new IllegalArgumentException();
+        }
+
+        return switch (unit) {
+            case BTU -> UnitSystem.IMPERIAL;
+            default -> UnitSystem.METRIC;
+        };
+    }
+
+    /**
+     * Gets all supported metric energy units.
+     *
+     * @return all supported metric energy units.
+     */
+    public static EnergyUnit[] getMetricUnits() {
+        return new EnergyUnit[]{
+                JOULE,
+                KILOJOULE,
+                CALORIE,
+                KILOCALORIE,
+                KILOWATT_HOUR
+        };
+    }
+
+    /**
+     * Gets all supported imperial energy units.
+     *
+     * @return all supported imperial energy units.
+     */
+    public static EnergyUnit[] getImperialUnits() {
+        return new EnergyUnit[]{
+                BTU
+        };
+    }
+
+    /**
+     * Indicates whether provided unit belongs to the metric unit system.
+     *
+     * @param unit energy unit to be checked.
+     * @return true if unit belongs to metric unit system.
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static boolean isMetric(final EnergyUnit unit) {
+        return getUnitSystem(unit) == UnitSystem.METRIC;
+    }
+
+    /**
+     * Indicates whether provided unit belongs to the imperial unit system.
+     *
+     * @param unit energy unit to be checked.
+     * @return true if unit belongs to imperial unit system.
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static boolean isImperial(final EnergyUnit unit) {
+        return getUnitSystem(unit) == UnitSystem.IMPERIAL;
+    }
+}

--- a/src/main/java/com/irurueta/units/Force.java
+++ b/src/main/java/com/irurueta/units/Force.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.math.BigDecimal;
+
+/**
+ * Contains a force value and unit.
+ */
+@SuppressWarnings("WeakerAccess")
+public class Force extends Measurement<ForceUnit> {
+
+    /**
+     * Constructor with value and unit.
+     *
+     * @param value force value.
+     * @param unit  unit of force.
+     * @throws IllegalArgumentException if either value or unit is null.
+     */
+    public Force(final Number value, final ForceUnit unit) {
+        super(value, unit);
+    }
+
+    /**
+     * Constructor.
+     */
+    Force() {
+        super();
+    }
+
+    /**
+     * Determines if two forces are equal up to a certain tolerance.
+     * If needed, this method attempts unit conversion to compare both objects.
+     *
+     * @param other     another force to compare.
+     * @param tolerance amount of tolerance to determine whether two force instances are equal or not.
+     * @return true if provided force is assumed to be equal to this instance,
+     * false otherwise.
+     */
+    @Override
+    public boolean equals(final Measurement<ForceUnit> other, final double tolerance) {
+        if (super.equals(other, tolerance)) {
+            return true;
+        }
+
+        //attempt conversion to common units
+        if (other == null) {
+            return false;
+        }
+
+        final var otherValue = ForceConverter.convert(other.getValue().doubleValue(), other.getUnit(), getUnit());
+        return Math.abs(getValue().doubleValue() - otherValue) <= tolerance;
+    }
+
+    /**
+     * Adds two force values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of addition.
+     */
+    public static double add(final double value1, final ForceUnit unit1,
+                             final double value2, final ForceUnit unit2,
+                             final ForceUnit resultUnit) {
+        final var v1 = ForceConverter.convert(value1, unit1, resultUnit);
+        final var v2 = ForceConverter.convert(value2, unit2, resultUnit);
+        return v1 + v2;
+    }
+
+    /**
+     * Adds two force values and unit and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of addition.
+     */
+    public static Number add(final Number value1, final ForceUnit unit1,
+                             final Number value2, final ForceUnit unit2,
+                             final ForceUnit resultUnit) {
+        return BigDecimal.valueOf(add(value1.doubleValue(), unit1, value2.doubleValue(), unit2, resultUnit));
+    }
+
+    /**
+     * Adds two force instances and stores the result into provided instance.
+     *
+     * @param arg1   1st argument.
+     * @param arg2   2nd argument.
+     * @param result instance where result will be stored.
+     */
+    public static void add(final Force arg1, final Force arg2, final Force result) {
+        result.setValue(add(arg1.getValue(), arg1.getUnit(), arg2.getValue(), arg2.getUnit(), result.getUnit()));
+    }
+
+    /**
+     * Adds two force instances.
+     *
+     * @param arg1 1st argument.
+     * @param arg2 2nd argument.
+     * @param unit unit of returned force.
+     * @return a new instance containing result.
+     */
+    public static Force addAndReturnNew(final Force arg1, final Force arg2, final ForceUnit unit) {
+        final var result = new Force();
+        result.setUnit(unit);
+        add(arg1, arg2, result);
+        return result;
+    }
+
+    /**
+     * Adds provided force value and unit and returns a new force instance using
+     * provided unit.
+     *
+     * @param value      value to be added.
+     * @param unit       unit of value to be added.
+     * @param resultUnit unit of returned force.
+     * @return a new force containing result.
+     */
+    public Force addAndReturnNew(
+            final double value, final ForceUnit unit, final ForceUnit resultUnit) {
+        final var result = new Force();
+        result.setUnit(resultUnit);
+        result.setValue(add(getValue().doubleValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Adds provided force value and unit and returns a new force instance using
+     * provided unit.
+     *
+     * @param value      value to be added.
+     * @param unit       unit of value to be added.
+     * @param resultUnit unit of returned force.
+     * @return a new force containing result.
+     */
+    public Force addAndReturnNew(
+            final Number value, final ForceUnit unit, final ForceUnit resultUnit) {
+        final var result = new Force();
+        result.setUnit(resultUnit);
+        result.setValue(add(getValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Adds provided force to current instance and returns a new force.
+     *
+     * @param f    force to be added.
+     * @param unit unit of returned force.
+     * @return a new force containing result.
+     */
+    public Force addAndReturnNew(final Force f, final ForceUnit unit) {
+        return addAndReturnNew(this, f, unit);
+    }
+
+    /**
+     * Adds provided force value and unit and updates current force instance.
+     *
+     * @param value force value to be added.
+     * @param unit  unit of force value.
+     */
+    public void add(final double value, final ForceUnit unit) {
+        setValue(add(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Adds provided force value and unit and updates current force instance.
+     *
+     * @param value force value to be added.
+     * @param unit  unit of force value.
+     */
+    public void add(final Number value, final ForceUnit unit) {
+        setValue(add(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Adds provided force and updates current force.
+     *
+     * @param force force to be added.
+     */
+    public void add(final Force force) {
+        add(this, force, this);
+    }
+
+    /**
+     * Adds provided force and stores the result into provided force.
+     *
+     * @param f      force to be added.
+     * @param result instance where result will be stored.
+     */
+    public void add(final Force f, final Force result) {
+        add(this, f, result);
+    }
+
+    /**
+     * Subtracts two force values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of subtraction.
+     */
+    public static double subtract(
+            final double value1, final ForceUnit unit1,
+            final double value2, final ForceUnit unit2,
+            final ForceUnit resultUnit) {
+        final var v1 = ForceConverter.convert(value1, unit1, resultUnit);
+        final var v2 = ForceConverter.convert(value2, unit2, resultUnit);
+        return v1 - v2;
+    }
+
+    /**
+     * Subtracts two force values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of subtraction.
+     */
+    public static Number subtract(
+            final Number value1, final ForceUnit unit1,
+            final Number value2, final ForceUnit unit2,
+            final ForceUnit resultUnit) {
+        return BigDecimal.valueOf(subtract(value1.doubleValue(), unit1, value2.doubleValue(), unit2, resultUnit));
+    }
+
+    /**
+     * Subtracts two force instances and stores the result into provided instance.
+     *
+     * @param arg1   1st argument.
+     * @param arg2   2nd argument.
+     * @param result instance where result will be stored.
+     */
+    public static void subtract(final Force arg1, final Force arg2, final Force result) {
+        result.setValue(subtract(arg1.getValue(), arg1.getUnit(), arg2.getValue(), arg2.getUnit(), result.getUnit()));
+    }
+
+    /**
+     * Subtracts two force instances.
+     *
+     * @param arg1 1st argument.
+     * @param arg2 2nd argument.
+     * @param unit unit of returned force.
+     * @return a new instance containing result.
+     */
+    public static Force subtractAndReturnNew(
+            final Force arg1, final Force arg2, final ForceUnit unit) {
+        final var result = new Force();
+        result.setUnit(unit);
+        subtract(arg1, arg2, result);
+        return result;
+    }
+
+    /**
+     * Subtracts provided force value and unit and returns a nw force instance using
+     * provided unit.
+     *
+     * @param value      value to be subtracted.
+     * @param unit       unit of value to be subtracted.
+     * @param resultUnit unit of returned force.
+     * @return a new force containing result.
+     */
+    public Force subtractAndReturnNew(
+            final double value, final ForceUnit unit, final ForceUnit resultUnit) {
+        final var result = new Force();
+        result.setUnit(resultUnit);
+        result.setValue(subtract(getValue().doubleValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Subtracts provided force value and unit and returns a new force instance using
+     * provided unit.
+     *
+     * @param value      value to be subtracted.
+     * @param unit       unit of value to be subtracted.
+     * @param resultUnit unit of returned force.
+     * @return a new force containing result.
+     */
+    public Force subtractAndReturnNew(
+            final Number value, final ForceUnit unit, final ForceUnit resultUnit) {
+        final var result = new Force();
+        result.setUnit(resultUnit);
+        result.setValue(subtract(getValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Subtracts provided force to current instance and returns a new force instance.
+     *
+     * @param f    force to be subtracted.
+     * @param unit unit of returned force.
+     * @return a new force containing result.
+     */
+    public Force subtractAndReturnNew(final Force f, final ForceUnit unit) {
+        return subtractAndReturnNew(this, f, unit);
+    }
+
+    /**
+     * Subtracts provided force value and unit and updates current force instance.
+     *
+     * @param value force value to be subtracted.
+     * @param unit  unit of force value.
+     */
+    public void subtract(final double value, final ForceUnit unit) {
+        setValue(subtract(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Subtracts provided force value and unit and updates current force instance.
+     *
+     * @param value force value to be subtracted.
+     * @param unit  unit of force value.
+     */
+    public void subtract(final Number value, final ForceUnit unit) {
+        setValue(subtract(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Subtracts provided force and updates current force.
+     *
+     * @param force force to be subtracted.
+     */
+    public void subtract(final Force force) {
+        subtract(this, force, this);
+    }
+
+    /**
+     * Subtracts provided force and stores the result into provided force.
+     *
+     * @param f      force to be subtracted.
+     * @param result instance where result will be stored.
+     */
+    public void subtract(final Force f, final Force result) {
+        subtract(this, f, result);
+    }
+}

--- a/src/main/java/com/irurueta/units/ForceConverter.java
+++ b/src/main/java/com/irurueta/units/ForceConverter.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.math.BigDecimal;
+
+/**
+ * Does force conversions to different units.
+ * To prevent loss of accuracy, conversion should only be done as a final step
+ * before displaying force measurements.
+ */
+@SuppressWarnings("WeakerAccess")
+public class ForceConverter {
+
+    /**
+     * Number of newtons in 1 pound-force.
+     */
+    static final double NEWTONS_PER_POUND_FORCE = 4.4482216152605;
+
+    /**
+     * Number of newtons in 1 dyne.
+     */
+    static final double NEWTONS_PER_DYNE = 0.00001;
+
+    /**
+     * Number of newtons in 1 kilogram-force.
+     */
+    static final double NEWTONS_PER_KILOGRAM_FORCE = 9.80665;
+
+    /**
+     * Number of newtons in 1 kilonewton.
+     */
+    static final double NEWTONS_PER_KILONEWTON = 1000.0;
+
+    /**
+     * Constructor.
+     * Prevents instantiation of helper class.
+     */
+    private ForceConverter() {
+    }
+
+    /**
+     * Converts a force instance to provided output force unit.
+     *
+     * @param input  input force to be converted.
+     * @param output output force where result will be stored containing output unit.
+     */
+    public static void convert(final Force input, final Force output) {
+        convert(input, output.getUnit(), output);
+    }
+
+    /**
+     * Converts a force instance to requested output unit.
+     *
+     * @param input      input force to be converted.
+     * @param outputUnit requested output unit.
+     * @return converted force.
+     */
+    public static Force convertAndReturnNew(
+            final Force input, final ForceUnit outputUnit) {
+        final var result = new Force();
+        convert(input, outputUnit, result);
+        return result;
+    }
+
+    /**
+     * Converts and updates a force to requested output unit.
+     *
+     * @param force      input force to be converted and updated.
+     * @param outputUnit requested output unit.
+     */
+    public static void convert(final Force force, final ForceUnit outputUnit) {
+        convert(force, outputUnit, force);
+    }
+
+    /**
+     * Converts a force to requested output unit.
+     *
+     * @param input      input force to be converted.
+     * @param outputUnit requested output unit.
+     * @param result     force instance where result will be stored.
+     */
+    public static void convert(
+            final Force input, final ForceUnit outputUnit, final Force result) {
+        final var value = convert(input.getValue(), input.getUnit(), outputUnit);
+        result.setValue(value);
+        result.setUnit(outputUnit);
+    }
+
+    /**
+     * Converts a force value from input unit to provided output unit.
+     *
+     * @param input      force value.
+     * @param inputUnit  input force unit.
+     * @param outputUnit output force unit.
+     * @return converted force value.
+     */
+    public static Number convert(final Number input, final ForceUnit inputUnit, final ForceUnit outputUnit) {
+        return BigDecimal.valueOf(convert(input.doubleValue(), inputUnit, outputUnit));
+    }
+
+    /**
+     * Converts a force value from input unit to provided output unit.
+     *
+     * @param input      force value.
+     * @param inputUnit  input force unit.
+     * @param outputUnit output force unit.
+     * @return converted force value.
+     */
+    public static double convert(final double input, final ForceUnit inputUnit, final ForceUnit outputUnit) {
+        //convert to newtons
+        final var newtons = switch (inputUnit) {
+            case POUND_FORCE -> poundForceToNewton(input);
+            case DYNE -> dyneToNewton(input);
+            case KILOGRAM_FORCE -> kilogramForceToNewton(input);
+            case KILONEWTON -> kilonewtonToNewton(input);
+            default -> input;
+        };
+
+        //convert from newtons to required output unit
+        return switch (outputUnit) {
+            case POUND_FORCE -> newtonToPoundForce(newtons);
+            case DYNE -> newtonToDyne(newtons);
+            case KILOGRAM_FORCE -> newtonToKilogramForce(newtons);
+            case KILONEWTON -> newtonToKilonewton(newtons);
+            default -> newtons;
+        };
+    }
+
+    /**
+     * Converts provided pound-force value to newtons.
+     *
+     * @param poundForce pound-force value.
+     * @return same force converted to newtons.
+     */
+    public static double poundForceToNewton(final double poundForce) {
+        return poundForce * NEWTONS_PER_POUND_FORCE;
+    }
+
+    /**
+     * Converts provided newton value to pound-force.
+     *
+     * @param newton newton value.
+     * @return same force converted to pound-force.
+     */
+    public static double newtonToPoundForce(final double newton) {
+        return newton / NEWTONS_PER_POUND_FORCE;
+    }
+
+    /**
+     * Converts provided dyne value to newtons.
+     *
+     * @param dyne dyne value.
+     * @return same force converted to newtons.
+     */
+    public static double dyneToNewton(final double dyne) {
+        return dyne * NEWTONS_PER_DYNE;
+    }
+
+    /**
+     * Converts provided newton value to dyne.
+     *
+     * @param newton newton value.
+     * @return same force converted to dyne.
+     */
+    public static double newtonToDyne(final double newton) {
+        return newton / NEWTONS_PER_DYNE;
+    }
+
+    /**
+     * Converts provided kilogram-force value to newtons.
+     *
+     * @param kilogramForce kilogram-force value.
+     * @return same force converted to newtons.
+     */
+    public static double kilogramForceToNewton(final double kilogramForce) {
+        return kilogramForce * NEWTONS_PER_KILOGRAM_FORCE;
+    }
+
+    /**
+     * Converts provided newton value to kilogram-force.
+     *
+     * @param newton newton value.
+     * @return same force converted to kilogram-force.
+     */
+    public static double newtonToKilogramForce(final double newton) {
+        return newton / NEWTONS_PER_KILOGRAM_FORCE;
+    }
+
+    /**
+     * Converts provided kilonewton value to newtons.
+     *
+     * @param kilonewton kilonewton value.
+     * @return same force converted to newtons.
+     */
+    public static double kilonewtonToNewton(final double kilonewton) {
+        return kilonewton * NEWTONS_PER_KILONEWTON;
+    }
+
+    /**
+     * Converts provided newton value to kilonewton.
+     *
+     * @param newton newton value.
+     * @return same force converted to kilonewton.
+     */
+    public static double newtonToKilonewton(final double newton) {
+        return newton / NEWTONS_PER_KILONEWTON;
+    }
+}

--- a/src/main/java/com/irurueta/units/ForceFormatter.java
+++ b/src/main/java/com/irurueta/units/ForceFormatter.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.text.ParseException;
+import java.util.Locale;
+
+/**
+ * Formats and parses force value and unit.
+ */
+public class ForceFormatter extends MeasureFormatter<Force, ForceUnit> {
+
+    /**
+     * Newton symbol.
+     */
+    public static final String NEWTON = "N";
+
+    /**
+     * Kilonewton symbol.
+     */
+    public static final String KILONEWTON = "kN";
+
+    /**
+     * Pound-force symbol.
+     */
+    public static final String POUND_FORCE = "lbf";
+
+    /**
+     * Dyne symbol.
+     */
+    public static final String DYNE = "dyn";
+
+    /**
+     * Kilogram-force symbol.
+     */
+    public static final String KILOGRAM_FORCE = "kgf";
+
+    /**
+     * Constructor.
+     */
+    public ForceFormatter() {
+        super();
+    }
+
+    /**
+     * Constructor with locale.
+     *
+     * @param locale locale.
+     * @throws IllegalArgumentException if locale is null.
+     */
+    public ForceFormatter(final Locale locale) {
+        super(locale);
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param formatter input instance to copy from.
+     * @throws NullPointerException if provided formatter is null.
+     */
+    public ForceFormatter(final ForceFormatter formatter) {
+        this(formatter.getLocale());
+    }
+
+    /**
+     * Determines if two force formatters are equal by comparing all of their internal
+     * parameters.
+     *
+     * @param obj another object to compare.
+     * @return true if provided object is assumed to be equal to this instance.
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        final var equals = super.equals(obj);
+        return (obj instanceof ForceFormatter) && equals;
+    }
+
+    /**
+     * Hash code generated for this instance.
+     * Hash codes can be internally used by some collections to coarsely compare objects.
+     * This implementation only calls parent implementation to avoid static analyzer warning.
+     *
+     * @return hash code.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * Gets unit system for detected unit into provided string representation
+     * of a measurement.
+     *
+     * @param source a measurement string representation to be checked.
+     * @return a unit system (either metric or imperial) or null if unit
+     * cannot be determined.
+     */
+    @Override
+    public UnitSystem getUnitSystem(final String source) {
+        final var unit = findUnit(source);
+        return unit != null ? ForceUnit.getUnitSystem(unit) : null;
+    }
+
+    /**
+     * Parses provided string and tries to determine force value and unit.
+     *
+     * @param source a string to be parsed.
+     * @return a force containing a value and unit.
+     * @throws ParseException       if provided string cannot be parsed.
+     * @throws UnknownUnitException if unit cannot be determined.
+     */
+    @Override
+    public Force parse(final String source) throws ParseException, UnknownUnitException {
+        return internalParse(source, new Force());
+    }
+
+    /**
+     * Attempts to determine a force unit within a measurement string representation.
+     *
+     * @param source a measurement string representation.
+     * @return a force unit, or null if none can be determined.
+     */
+    @Override
+    public ForceUnit findUnit(final String source) {
+        if (source.contains(KILONEWTON + " ") || source.endsWith(KILONEWTON)) {
+            return ForceUnit.KILONEWTON;
+        }
+        if (source.contains(POUND_FORCE + " ") || source.endsWith(POUND_FORCE)) {
+            return ForceUnit.POUND_FORCE;
+        }
+        if (source.contains(DYNE + " ") || source.endsWith(DYNE)) {
+            return ForceUnit.DYNE;
+        }
+        if (source.contains(KILOGRAM_FORCE + " ") || source.endsWith(KILOGRAM_FORCE)) {
+            return ForceUnit.KILOGRAM_FORCE;
+        }
+        if (source.contains(NEWTON + " ") || source.endsWith(NEWTON)) {
+            return ForceUnit.NEWTON;
+        }
+        return null;
+    }
+
+    /**
+     * Formats and converts provided force value and unit using provided
+     * unit system.
+     * If provided value is too large for provided unit, this method will
+     * convert it to a more appropriate unit using provided unit system (either
+     * metric or imperial).
+     *
+     * @param value  a force value.
+     * @param unit   a force unit.
+     * @param system system unit to convert force to.
+     * @return a string representation of force value and unit.
+     */
+    @Override
+    public String formatAndConvert(final Number value, final ForceUnit unit, final UnitSystem system) {
+        if (system == UnitSystem.IMPERIAL) {
+            return formatAndConvertImperial(value, unit);
+        } else {
+            return formatAndConvertMetric(value, unit);
+        }
+    }
+
+    /**
+     * Formats and converts provided force value and unit using metric unit system.
+     *
+     * @param value a force value.
+     * @param unit  a force unit.
+     * @return a string representation of force value and unit using metric unit system.
+     */
+    public String formatAndConvertMetric(final Number value, final ForceUnit unit) {
+        //always format as newtons
+        return format(ForceConverter.convert(value, unit, ForceUnit.NEWTON), ForceUnit.NEWTON);
+    }
+
+    /**
+     * Formats and converts provided force value and unit using imperial unit system.
+     *
+     * @param value a force value.
+     * @param unit  a force unit.
+     * @return a string representation of force value and unit using imperial unit system.
+     */
+    public String formatAndConvertImperial(final Number value, final ForceUnit unit) {
+        //always format as pound-force
+        return format(ForceConverter.convert(value, unit, ForceUnit.POUND_FORCE), ForceUnit.POUND_FORCE);
+    }
+
+    /**
+     * Returns unit string representation.
+     *
+     * @param unit a force unit.
+     * @return its string representation.
+     */
+    @Override
+    public String getUnitSymbol(final ForceUnit unit) {
+        return switch (unit) {
+            case KILONEWTON -> KILONEWTON;
+            case POUND_FORCE -> POUND_FORCE;
+            case DYNE -> DYNE;
+            case KILOGRAM_FORCE -> KILOGRAM_FORCE;
+            default -> NEWTON;
+        };
+    }
+}

--- a/src/main/java/com/irurueta/units/ForceUnit.java
+++ b/src/main/java/com/irurueta/units/ForceUnit.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+/**
+ * Enumerator containing recognized typical force units.
+ */
+public enum ForceUnit {
+    /**
+     * Newton (N).
+     */
+    NEWTON,
+
+    /**
+     * Kilonewton (kN).
+     */
+    KILONEWTON,
+
+    /**
+     * Pound-force (lbf).
+     */
+    POUND_FORCE,
+
+    /**
+     * Dyne (dyn).
+     */
+    DYNE,
+
+    /**
+     * Kilogram-force (kgf).
+     */
+    KILOGRAM_FORCE;
+
+    /**
+     * Returns unit system for provided force unit.
+     *
+     * @param unit force unit to be checked.
+     * @return unit system (metric or imperial).
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static UnitSystem getUnitSystem(final ForceUnit unit) {
+        if (unit == null) {
+            throw new IllegalArgumentException();
+        }
+
+        return switch (unit) {
+            case POUND_FORCE -> UnitSystem.IMPERIAL;
+            default -> UnitSystem.METRIC;
+        };
+    }
+
+    /**
+     * Gets all supported metric force units.
+     *
+     * @return all supported metric force units.
+     */
+    public static ForceUnit[] getMetricUnits() {
+        return new ForceUnit[]{
+                NEWTON,
+                KILONEWTON,
+                DYNE,
+                KILOGRAM_FORCE
+        };
+    }
+
+    /**
+     * Gets all supported imperial force units.
+     *
+     * @return all supported imperial force units.
+     */
+    public static ForceUnit[] getImperialUnits() {
+        return new ForceUnit[]{
+                POUND_FORCE
+        };
+    }
+
+    /**
+     * Indicates whether provided unit belongs to the metric unit system.
+     *
+     * @param unit force unit to be checked.
+     * @return true if unit belongs to metric unit system.
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static boolean isMetric(final ForceUnit unit) {
+        return getUnitSystem(unit) == UnitSystem.METRIC;
+    }
+
+    /**
+     * Indicates whether provided unit belongs to the imperial unit system.
+     *
+     * @param unit force unit to be checked.
+     * @return true if unit belongs to imperial unit system.
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static boolean isImperial(final ForceUnit unit) {
+        return getUnitSystem(unit) == UnitSystem.IMPERIAL;
+    }
+}

--- a/src/main/java/com/irurueta/units/Power.java
+++ b/src/main/java/com/irurueta/units/Power.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.math.BigDecimal;
+
+/**
+ * Contains a power value and unit.
+ */
+@SuppressWarnings("WeakerAccess")
+public class Power extends Measurement<PowerUnit> {
+
+    /**
+     * Constructor with value and unit.
+     *
+     * @param value power value.
+     * @param unit  unit of power.
+     * @throws IllegalArgumentException if either value or unit is null.
+     */
+    public Power(final Number value, final PowerUnit unit) {
+        super(value, unit);
+    }
+
+    /**
+     * Constructor.
+     */
+    Power() {
+        super();
+    }
+
+    /**
+     * Determines if two powers are equal up to a certain tolerance.
+     * If needed, this method attempts unit conversion to compare both objects.
+     *
+     * @param other     another power to compare.
+     * @param tolerance amount of tolerance to determine whether two power instances are equal or not.
+     * @return true if provided power is assumed to be equal to this instance,
+     * false otherwise.
+     */
+    @Override
+    public boolean equals(final Measurement<PowerUnit> other, final double tolerance) {
+        if (super.equals(other, tolerance)) {
+            return true;
+        }
+
+        //attempt conversion to common units
+        if (other == null) {
+            return false;
+        }
+
+        final var otherValue = PowerConverter.convert(
+                other.getValue().doubleValue(), other.getUnit(), getUnit());
+        return Math.abs(getValue().doubleValue() - otherValue) <= tolerance;
+    }
+
+    /**
+     * Adds two power values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of addition.
+     */
+    public static double add(final double value1, final PowerUnit unit1,
+                             final double value2, final PowerUnit unit2,
+                             final PowerUnit resultUnit) {
+        final var v1 = PowerConverter.convert(value1, unit1, resultUnit);
+        final var v2 = PowerConverter.convert(value2, unit2, resultUnit);
+        return v1 + v2;
+    }
+
+    /**
+     * Adds two power values and unit and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of addition.
+     */
+    public static Number add(final Number value1, final PowerUnit unit1,
+                             final Number value2, final PowerUnit unit2,
+                             final PowerUnit resultUnit) {
+        return BigDecimal.valueOf(add(value1.doubleValue(), unit1, value2.doubleValue(), unit2, resultUnit));
+    }
+
+    /**
+     * Adds two power instances and stores the result into provided instance.
+     *
+     * @param arg1   1st argument.
+     * @param arg2   2nd argument.
+     * @param result instance where result will be stored.
+     */
+    public static void add(final Power arg1, final Power arg2, final Power result) {
+        result.setValue(add(arg1.getValue(), arg1.getUnit(), arg2.getValue(), arg2.getUnit(), result.getUnit()));
+    }
+
+    /**
+     * Adds two power instances.
+     *
+     * @param arg1 1st argument.
+     * @param arg2 2nd argument.
+     * @param unit unit of returned power.
+     * @return a new instance containing result.
+     */
+    public static Power addAndReturnNew(final Power arg1, final Power arg2, final PowerUnit unit) {
+        final var result = new Power();
+        result.setUnit(unit);
+        add(arg1, arg2, result);
+        return result;
+    }
+
+    /**
+     * Adds provided power value and unit and returns a new power instance using
+     * provided unit.
+     *
+     * @param value      value to be added.
+     * @param unit       unit of value to be added.
+     * @param resultUnit unit of returned power.
+     * @return a new power containing result.
+     */
+    public Power addAndReturnNew(
+            final double value, final PowerUnit unit, final PowerUnit resultUnit) {
+        final var result = new Power();
+        result.setUnit(resultUnit);
+        result.setValue(add(getValue().doubleValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Adds provided power value and unit and returns a new power instance using
+     * provided unit.
+     *
+     * @param value      value to be added.
+     * @param unit       unit of value to be added.
+     * @param resultUnit unit of returned power.
+     * @return a new power containing result.
+     */
+    public Power addAndReturnNew(
+            final Number value, final PowerUnit unit, final PowerUnit resultUnit) {
+        final var result = new Power();
+        result.setUnit(resultUnit);
+        result.setValue(add(getValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Adds provided power to current instance and returns a new power.
+     *
+     * @param p    power to be added.
+     * @param unit unit of returned power.
+     * @return a new power containing result.
+     */
+    public Power addAndReturnNew(final Power p, final PowerUnit unit) {
+        return addAndReturnNew(this, p, unit);
+    }
+
+    /**
+     * Adds provided power value and unit and updates current power instance.
+     *
+     * @param value power value to be added.
+     * @param unit  unit of power value.
+     */
+    public void add(final double value, final PowerUnit unit) {
+        setValue(add(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Adds provided power value and unit and updates current power instance.
+     *
+     * @param value power value to be added.
+     * @param unit  unit of power value.
+     */
+    public void add(final Number value, final PowerUnit unit) {
+        setValue(add(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Adds provided power and updates current power.
+     *
+     * @param power power to be added.
+     */
+    public void add(final Power power) {
+        add(this, power, this);
+    }
+
+    /**
+     * Adds provided power and stores the result into provided power.
+     *
+     * @param p      power to be added.
+     * @param result instance where result will be stored.
+     */
+    public void add(final Power p, final Power result) {
+        add(this, p, result);
+    }
+
+    /**
+     * Subtracts two power values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of subtraction.
+     */
+    public static double subtract(
+            final double value1, final PowerUnit unit1,
+            final double value2, final PowerUnit unit2,
+            final PowerUnit resultUnit) {
+        final var v1 = PowerConverter.convert(value1, unit1, resultUnit);
+        final var v2 = PowerConverter.convert(value2, unit2, resultUnit);
+        return v1 - v2;
+    }
+
+    /**
+     * Subtracts two power values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of subtraction.
+     */
+    public static Number subtract(
+            final Number value1, final PowerUnit unit1,
+            final Number value2, final PowerUnit unit2,
+            final PowerUnit resultUnit) {
+        return BigDecimal.valueOf(subtract(value1.doubleValue(), unit1, value2.doubleValue(), unit2, resultUnit));
+    }
+
+    /**
+     * Subtracts two power instances and stores the result into provided instance.
+     *
+     * @param arg1   1st argument.
+     * @param arg2   2nd argument.
+     * @param result instance where result will be stored.
+     */
+    public static void subtract(final Power arg1, final Power arg2, final Power result) {
+        result.setValue(subtract(
+                arg1.getValue(), arg1.getUnit(), arg2.getValue(), arg2.getUnit(), result.getUnit()));
+    }
+
+    /**
+     * Subtracts two power instances.
+     *
+     * @param arg1 1st argument.
+     * @param arg2 2nd argument.
+     * @param unit unit of returned power.
+     * @return a new instance containing result.
+     */
+    public static Power subtractAndReturnNew(
+            final Power arg1, final Power arg2, final PowerUnit unit) {
+        final var result = new Power();
+        result.setUnit(unit);
+        subtract(arg1, arg2, result);
+        return result;
+    }
+
+    /**
+     * Subtracts provided power value and unit and returns a nw power instance using
+     * provided unit.
+     *
+     * @param value      value to be subtracted.
+     * @param unit       unit of value to be subtracted.
+     * @param resultUnit unit of returned power.
+     * @return a new power containing result.
+     */
+    public Power subtractAndReturnNew(
+            final double value, final PowerUnit unit, final PowerUnit resultUnit) {
+        final var result = new Power();
+        result.setUnit(resultUnit);
+        result.setValue(subtract(getValue().doubleValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Subtracts provided power value and unit and returns a new power instance using
+     * provided unit.
+     *
+     * @param value      value to be subtracted.
+     * @param unit       unit of value to be subtracted.
+     * @param resultUnit unit of returned power.
+     * @return a new power containing result.
+     */
+    public Power subtractAndReturnNew(
+            final Number value, final PowerUnit unit, final PowerUnit resultUnit) {
+        final var result = new Power();
+        result.setUnit(resultUnit);
+        result.setValue(subtract(getValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Subtracts provided power to current instance and returns a new power instance.
+     *
+     * @param p    power to be subtracted.
+     * @param unit unit of returned power.
+     * @return a new power containing result.
+     */
+    public Power subtractAndReturnNew(final Power p, final PowerUnit unit) {
+        return subtractAndReturnNew(this, p, unit);
+    }
+
+    /**
+     * Subtracts provided power value and unit and updates current power instance.
+     *
+     * @param value power value to be subtracted.
+     * @param unit  unit of power value.
+     */
+    public void subtract(final double value, final PowerUnit unit) {
+        setValue(subtract(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Subtracts provided power value and unit and updates current power instance.
+     *
+     * @param value power value to be subtracted.
+     * @param unit  unit of power value.
+     */
+    public void subtract(final Number value, final PowerUnit unit) {
+        setValue(subtract(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Subtracts provided power and updates current power.
+     *
+     * @param power power to be subtracted.
+     */
+    public void subtract(final Power power) {
+        subtract(this, power, this);
+    }
+
+    /**
+     * Subtracts provided power and stores the result into provided power.
+     *
+     * @param p      power to be subtracted.
+     * @param result instance where result will be stored.
+     */
+    public void subtract(final Power p, final Power result) {
+        subtract(this, p, result);
+    }
+}

--- a/src/main/java/com/irurueta/units/PowerConverter.java
+++ b/src/main/java/com/irurueta/units/PowerConverter.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.math.BigDecimal;
+
+/**
+ * Does power conversions to different units.
+ * To prevent loss of accuracy, conversion should only be done as a final step
+ * before displaying power measurements.
+ */
+@SuppressWarnings("WeakerAccess")
+public class PowerConverter {
+
+    /**
+     * Number of watts in 1 kilowatt.
+     */
+    static final double WATTS_PER_KILOWATT = 1000.0;
+
+    /**
+     * Number of watts in 1 megawatt.
+     */
+    static final double WATTS_PER_MEGAWATT = 1000000.0;
+
+    /**
+     * Number of watts in 1 horsepower.
+     */
+    static final double WATTS_PER_HORSEPOWER = 745.699872;
+
+    /**
+     * Constructor.
+     * Prevents instantiation of helper class.
+     */
+    private PowerConverter() {
+    }
+
+    /**
+     * Converts a power instance to provided output power unit.
+     *
+     * @param input  input power to be converted.
+     * @param output output power where result will be stored containing output unit.
+     */
+    public static void convert(final Power input, final Power output) {
+        convert(input, output.getUnit(), output);
+    }
+
+    /**
+     * Converts a power instance to requested output unit.
+     *
+     * @param input      input power to be converted.
+     * @param outputUnit requested output unit.
+     * @return converted power.
+     */
+    public static Power convertAndReturnNew(
+            final Power input, final PowerUnit outputUnit) {
+        final var result = new Power();
+        convert(input, outputUnit, result);
+        return result;
+    }
+
+    /**
+     * Converts and updates a power to requested output unit.
+     *
+     * @param power      input power to be converted and updated.
+     * @param outputUnit requested output unit.
+     */
+    public static void convert(final Power power, final PowerUnit outputUnit) {
+        convert(power, outputUnit, power);
+    }
+
+    /**
+     * Converts a power to requested output unit.
+     *
+     * @param input      input power to be converted.
+     * @param outputUnit requested output unit.
+     * @param result     power instance where result will be stored.
+     */
+    public static void convert(
+            final Power input, final PowerUnit outputUnit, final Power result) {
+        final var value = convert(input.getValue(), input.getUnit(), outputUnit);
+        result.setValue(value);
+        result.setUnit(outputUnit);
+    }
+
+    /**
+     * Converts a power value from input unit to provided output unit.
+     *
+     * @param input      power value.
+     * @param inputUnit  input power unit.
+     * @param outputUnit output power unit.
+     * @return converted power value.
+     */
+    public static Number convert(final Number input, final PowerUnit inputUnit, final PowerUnit outputUnit) {
+        return BigDecimal.valueOf(convert(input.doubleValue(), inputUnit, outputUnit));
+    }
+
+    /**
+     * Converts a power value from input unit to provided output unit.
+     *
+     * @param input      power value.
+     * @param inputUnit  input power unit.
+     * @param outputUnit output power unit.
+     * @return converted power value.
+     */
+    public static double convert(final double input, final PowerUnit inputUnit, final PowerUnit outputUnit) {
+        //convert to watts
+        final var watts = switch (inputUnit) {
+            case KILOWATT -> kilowattToWatt(input);
+            case MEGAWATT -> megawattToWatt(input);
+            case HORSEPOWER -> horsepowerToWatt(input);
+            default -> input;
+        };
+
+        //convert from watts to required output unit
+        return switch (outputUnit) {
+            case KILOWATT -> wattToKilowatt(watts);
+            case MEGAWATT -> wattToMegawatt(watts);
+            case HORSEPOWER -> wattToHorsepower(watts);
+            default -> watts;
+        };
+    }
+
+    /**
+     * Converts provided kilowatt value to watt.
+     *
+     * @param kilowatt kilowatt value.
+     * @return same power converted to watt.
+     */
+    public static double kilowattToWatt(final double kilowatt) {
+        return kilowatt * WATTS_PER_KILOWATT;
+    }
+
+    /**
+     * Converts provided watt value to kilowatt.
+     *
+     * @param watt watt value.
+     * @return same power converted to kilowatt.
+     */
+    public static double wattToKilowatt(final double watt) {
+        return watt / WATTS_PER_KILOWATT;
+    }
+
+    /**
+     * Converts provided megawatt value to watt.
+     *
+     * @param megawatt megawatt value.
+     * @return same power converted to watt.
+     */
+    public static double megawattToWatt(final double megawatt) {
+        return megawatt * WATTS_PER_MEGAWATT;
+    }
+
+    /**
+     * Converts provided watt value to megawatt.
+     *
+     * @param watt watt value.
+     * @return same power converted to megawatt.
+     */
+    public static double wattToMegawatt(final double watt) {
+        return watt / WATTS_PER_MEGAWATT;
+    }
+
+    /**
+     * Converts provided horsepower value to watt.
+     *
+     * @param horsepower horsepower value.
+     * @return same power converted to watt.
+     */
+    public static double horsepowerToWatt(final double horsepower) {
+        return horsepower * WATTS_PER_HORSEPOWER;
+    }
+
+    /**
+     * Converts provided watt value to horsepower.
+     *
+     * @param watt watt value.
+     * @return same power converted to horsepower.
+     */
+    public static double wattToHorsepower(final double watt) {
+        return watt / WATTS_PER_HORSEPOWER;
+    }
+}

--- a/src/main/java/com/irurueta/units/PowerFormatter.java
+++ b/src/main/java/com/irurueta/units/PowerFormatter.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.text.ParseException;
+import java.util.Locale;
+
+/**
+ * Formats and parses power value and unit.
+ */
+public class PowerFormatter extends MeasureFormatter<Power, PowerUnit> {
+
+    /**
+     * Watt symbol.
+     */
+    public static final String WATT = "W";
+
+    /**
+     * Kilowatt symbol.
+     */
+    public static final String KILOWATT = "kW";
+
+    /**
+     * Megawatt symbol.
+     */
+    public static final String MEGAWATT = "MW";
+
+    /**
+     * Horsepower symbol.
+     */
+    public static final String HORSEPOWER = "hp";
+
+    /**
+     * Constructor.
+     */
+    public PowerFormatter() {
+        super();
+    }
+
+    /**
+     * Constructor with locale.
+     *
+     * @param locale locale.
+     * @throws IllegalArgumentException if locale is null.
+     */
+    public PowerFormatter(final Locale locale) {
+        super(locale);
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param formatter input instance to copy from.
+     * @throws NullPointerException if provided formatter is null.
+     */
+    public PowerFormatter(final PowerFormatter formatter) {
+        this(formatter.getLocale());
+    }
+
+    /**
+     * Determines if two power formatters are equal by comparing all of their internal
+     * parameters.
+     *
+     * @param obj another object to compare.
+     * @return true if provided object is assumed to be equal to this instance.
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        final var equals = super.equals(obj);
+        return (obj instanceof PowerFormatter) && equals;
+    }
+
+    /**
+     * Hash code generated for this instance.
+     * Hash codes can be internally used by some collections to coarsely compare objects.
+     * This implementation only calls parent implementation to avoid static analyzer warning.
+     *
+     * @return hash code.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * Gets unit system for detected unit into provided string representation
+     * of a measurement.
+     *
+     * @param source a measurement string representation to be checked.
+     * @return a unit system (either metric or imperial) or null if unit
+     * cannot be determined.
+     */
+    @Override
+    public UnitSystem getUnitSystem(final String source) {
+        final var unit = findUnit(source);
+        return unit != null ? PowerUnit.getUnitSystem(unit) : null;
+    }
+
+    /**
+     * Parses provided string and tries to determine power value and unit.
+     *
+     * @param source a string to be parsed.
+     * @return a power containing a value and unit.
+     * @throws ParseException       if provided string cannot be parsed.
+     * @throws UnknownUnitException if unit cannot be determined.
+     */
+    @Override
+    public Power parse(final String source) throws ParseException, UnknownUnitException {
+        return internalParse(source, new Power());
+    }
+
+    /**
+     * Attempts to determine a power unit within a measurement string representation.
+     *
+     * @param source a measurement string representation.
+     * @return a power unit, or null if none can be determined.
+     */
+    @Override
+    public PowerUnit findUnit(final String source) {
+        if (source.contains(KILOWATT + " ") || source.endsWith(KILOWATT)) {
+            return PowerUnit.KILOWATT;
+        }
+        if (source.contains(MEGAWATT + " ") || source.endsWith(MEGAWATT)) {
+            return PowerUnit.MEGAWATT;
+        }
+        if (source.contains(HORSEPOWER + " ") || source.endsWith(HORSEPOWER)) {
+            return PowerUnit.HORSEPOWER;
+        }
+        if (source.contains(WATT + " ") || source.endsWith(WATT)) {
+            return PowerUnit.WATT;
+        }
+        return null;
+    }
+
+    /**
+     * Formats and converts provided power value and unit using provided
+     * unit system.
+     * If provided value is too large for provided unit, this method will
+     * convert it to a more appropriate unit using provided unit system (either
+     * metric or imperial).
+     *
+     * @param value  a power value.
+     * @param unit   a power unit.
+     * @param system system unit to convert power to.
+     * @return a string representation of power value and unit.
+     */
+    @Override
+    public String formatAndConvert(final Number value, final PowerUnit unit, final UnitSystem system) {
+        if (system == UnitSystem.IMPERIAL) {
+            return formatAndConvertImperial(value, unit);
+        } else {
+            return formatAndConvertMetric(value, unit);
+        }
+    }
+
+    /**
+     * Formats and converts provided power value and unit using metric unit system.
+     *
+     * @param value a power value.
+     * @param unit  a power unit.
+     * @return a string representation of power value and unit using metric unit system.
+     */
+    public String formatAndConvertMetric(final Number value, final PowerUnit unit) {
+        //always format as watts
+        return format(PowerConverter.convert(value, unit, PowerUnit.WATT), PowerUnit.WATT);
+    }
+
+    /**
+     * Formats and converts provided power value and unit using imperial unit system.
+     *
+     * @param value a power value.
+     * @param unit  a power unit.
+     * @return a string representation of power value and unit using imperial unit system.
+     */
+    public String formatAndConvertImperial(final Number value, final PowerUnit unit) {
+        //always format as horsepower
+        return format(PowerConverter.convert(value, unit, PowerUnit.HORSEPOWER), PowerUnit.HORSEPOWER);
+    }
+
+    /**
+     * Returns unit string representation.
+     *
+     * @param unit a power unit.
+     * @return its string representation.
+     */
+    @Override
+    public String getUnitSymbol(final PowerUnit unit) {
+        return switch (unit) {
+            case KILOWATT -> KILOWATT;
+            case MEGAWATT -> MEGAWATT;
+            case HORSEPOWER -> HORSEPOWER;
+            default -> WATT;
+        };
+    }
+}

--- a/src/main/java/com/irurueta/units/PowerUnit.java
+++ b/src/main/java/com/irurueta/units/PowerUnit.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+/**
+ * Enumerator containing recognized typical power units.
+ */
+public enum PowerUnit {
+    /**
+     * Watt (W).
+     */
+    WATT,
+
+    /**
+     * Kilowatt (kW).
+     */
+    KILOWATT,
+
+    /**
+     * Megawatt (MW).
+     */
+    MEGAWATT,
+
+    /**
+     * Horsepower (hp).
+     */
+    HORSEPOWER;
+
+    /**
+     * Returns unit system for provided power unit.
+     *
+     * @param unit power unit to be checked.
+     * @return unit system (metric or imperial).
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static UnitSystem getUnitSystem(final PowerUnit unit) {
+        if (unit == null) {
+            throw new IllegalArgumentException();
+        }
+
+        return switch (unit) {
+            case HORSEPOWER -> UnitSystem.IMPERIAL;
+            default -> UnitSystem.METRIC;
+        };
+    }
+
+    /**
+     * Gets all supported metric power units.
+     *
+     * @return all supported metric power units.
+     */
+    public static PowerUnit[] getMetricUnits() {
+        return new PowerUnit[]{
+            WATT,
+            KILOWATT,
+            MEGAWATT
+        };
+    }
+
+    /**
+     * Gets all supported imperial power units.
+     *
+     * @return all supported imperial power units.
+     */
+    public static PowerUnit[] getImperialUnits() {
+        return new PowerUnit[]{
+            HORSEPOWER
+        };
+    }
+
+    /**
+     * Indicates whether provided unit belongs to the metric unit system.
+     *
+     * @param unit power unit to be checked.
+     * @return true if unit belongs to metric unit system.
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static boolean isMetric(final PowerUnit unit) {
+        return getUnitSystem(unit) == UnitSystem.METRIC;
+    }
+
+    /**
+     * Indicates whether provided unit belongs to the imperial unit system.
+     *
+     * @param unit power unit to be checked.
+     * @return true if unit belongs to imperial unit system.
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static boolean isImperial(final PowerUnit unit) {
+        return getUnitSystem(unit) == UnitSystem.IMPERIAL;
+    }
+}

--- a/src/main/java/com/irurueta/units/Pressure.java
+++ b/src/main/java/com/irurueta/units/Pressure.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.math.BigDecimal;
+
+/**
+ * Contains a pressure value and unit.
+ */
+@SuppressWarnings("WeakerAccess")
+public class Pressure extends Measurement<PressureUnit> {
+
+    /**
+     * Constructor with value and unit.
+     *
+     * @param value pressure value.
+     * @param unit  unit of pressure.
+     * @throws IllegalArgumentException if either value or unit is null.
+     */
+    public Pressure(final Number value, final PressureUnit unit) {
+        super(value, unit);
+    }
+
+    /**
+     * Constructor.
+     */
+    Pressure() {
+        super();
+    }
+
+    /**
+     * Determines if two pressures are equal up to a certain tolerance.
+     * If needed, this method attempts unit conversion to compare both objects.
+     *
+     * @param other     another pressure to compare.
+     * @param tolerance amount of tolerance to determine whether two pressure instances are equal or not.
+     * @return true if provided pressure is assumed to be equal to this instance,
+     * false otherwise.
+     */
+    @Override
+    public boolean equals(final Measurement<PressureUnit> other, final double tolerance) {
+        if (super.equals(other, tolerance)) {
+            return true;
+        }
+
+        //attempt conversion to common units
+        if (other == null) {
+            return false;
+        }
+
+        final var otherValue = PressureConverter.convert(
+                other.getValue().doubleValue(), other.getUnit(), getUnit());
+        return Math.abs(getValue().doubleValue() - otherValue) <= tolerance;
+    }
+
+    /**
+     * Adds two pressure values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of addition.
+     */
+    public static double add(final double value1, final PressureUnit unit1,
+                             final double value2, final PressureUnit unit2,
+                             final PressureUnit resultUnit) {
+        final var v1 = PressureConverter.convert(value1, unit1, resultUnit);
+        final var v2 = PressureConverter.convert(value2, unit2, resultUnit);
+        return v1 + v2;
+    }
+
+    /**
+     * Adds two pressure values and unit and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of addition.
+     */
+    public static Number add(final Number value1, final PressureUnit unit1,
+                             final Number value2, final PressureUnit unit2,
+                             final PressureUnit resultUnit) {
+        return BigDecimal.valueOf(add(value1.doubleValue(), unit1, value2.doubleValue(), unit2, resultUnit));
+    }
+
+    /**
+     * Adds two pressure instances and stores the result into provided instance.
+     *
+     * @param arg1   1st argument.
+     * @param arg2   2nd argument.
+     * @param result instance where result will be stored.
+     */
+    public static void add(final Pressure arg1, final Pressure arg2, final Pressure result) {
+        result.setValue(add(arg1.getValue(), arg1.getUnit(), arg2.getValue(), arg2.getUnit(), result.getUnit()));
+    }
+
+    /**
+     * Adds two pressure instances.
+     *
+     * @param arg1 1st argument.
+     * @param arg2 2nd argument.
+     * @param unit unit of returned pressure.
+     * @return a new instance containing result.
+     */
+    public static Pressure addAndReturnNew(final Pressure arg1, final Pressure arg2, final PressureUnit unit) {
+        final var result = new Pressure();
+        result.setUnit(unit);
+        add(arg1, arg2, result);
+        return result;
+    }
+
+    /**
+     * Adds provided pressure value and unit and returns a new pressure instance using
+     * provided unit.
+     *
+     * @param value      value to be added.
+     * @param unit       unit of value to be added.
+     * @param resultUnit unit of returned pressure.
+     * @return a new pressure containing result.
+     */
+    public Pressure addAndReturnNew(
+            final double value, final PressureUnit unit, final PressureUnit resultUnit) {
+        final var result = new Pressure();
+        result.setUnit(resultUnit);
+        result.setValue(add(getValue().doubleValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Adds provided pressure value and unit and returns a new pressure instance using
+     * provided unit.
+     *
+     * @param value      value to be added.
+     * @param unit       unit of value to be added.
+     * @param resultUnit unit of returned pressure.
+     * @return a new pressure containing result.
+     */
+    public Pressure addAndReturnNew(
+            final Number value, final PressureUnit unit, final PressureUnit resultUnit) {
+        final var result = new Pressure();
+        result.setUnit(resultUnit);
+        result.setValue(add(getValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Adds provided pressure to current instance and returns a new pressure.
+     *
+     * @param p    pressure to be added.
+     * @param unit unit of returned pressure.
+     * @return a new pressure containing result.
+     */
+    public Pressure addAndReturnNew(final Pressure p, final PressureUnit unit) {
+        return addAndReturnNew(this, p, unit);
+    }
+
+    /**
+     * Adds provided pressure value and unit and updates current pressure instance.
+     *
+     * @param value pressure value to be added.
+     * @param unit  unit of pressure value.
+     */
+    public void add(final double value, final PressureUnit unit) {
+        setValue(add(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Adds provided pressure value and unit and updates current pressure instance.
+     *
+     * @param value pressure value to be added.
+     * @param unit  unit of pressure value.
+     */
+    public void add(final Number value, final PressureUnit unit) {
+        setValue(add(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Adds provided pressure and updates current pressure.
+     *
+     * @param pressure pressure to be added.
+     */
+    public void add(final Pressure pressure) {
+        add(this, pressure, this);
+    }
+
+    /**
+     * Adds provided pressure and stores the result into provided pressure.
+     *
+     * @param p      pressure to be added.
+     * @param result instance where result will be stored.
+     */
+    public void add(final Pressure p, final Pressure result) {
+        add(this, p, result);
+    }
+
+    /**
+     * Subtracts two pressure values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of subtraction.
+     */
+    public static double subtract(
+            final double value1, final PressureUnit unit1,
+            final double value2, final PressureUnit unit2,
+            final PressureUnit resultUnit) {
+        final var v1 = PressureConverter.convert(value1, unit1, resultUnit);
+        final var v2 = PressureConverter.convert(value2, unit2, resultUnit);
+        return v1 - v2;
+    }
+
+    /**
+     * Subtracts two pressure values and units and returns the result.
+     *
+     * @param value1     1st argument value.
+     * @param unit1      1st argument unit.
+     * @param value2     2nd argument value.
+     * @param unit2      2nd argument unit.
+     * @param resultUnit unit of result to be returned.
+     * @return result of subtraction.
+     */
+    public static Number subtract(
+            final Number value1, final PressureUnit unit1,
+            final Number value2, final PressureUnit unit2,
+            final PressureUnit resultUnit) {
+        return BigDecimal.valueOf(subtract(value1.doubleValue(), unit1, value2.doubleValue(), unit2, resultUnit));
+    }
+
+    /**
+     * Subtracts two pressure instances and stores the result into provided instance.
+     *
+     * @param arg1   1st argument.
+     * @param arg2   2nd argument.
+     * @param result instance where result will be stored.
+     */
+    public static void subtract(final Pressure arg1, final Pressure arg2, final Pressure result) {
+        result.setValue(subtract(
+                arg1.getValue(), arg1.getUnit(), arg2.getValue(), arg2.getUnit(), result.getUnit()));
+    }
+
+    /**
+     * Subtracts two pressure instances.
+     *
+     * @param arg1 1st argument.
+     * @param arg2 2nd argument.
+     * @param unit unit of returned pressure.
+     * @return a new instance containing result.
+     */
+    public static Pressure subtractAndReturnNew(
+            final Pressure arg1, final Pressure arg2, final PressureUnit unit) {
+        final var result = new Pressure();
+        result.setUnit(unit);
+        subtract(arg1, arg2, result);
+        return result;
+    }
+
+    /**
+     * Subtracts provided pressure value and unit and returns a nw pressure instance using
+     * provided unit.
+     *
+     * @param value      value to be subtracted.
+     * @param unit       unit of value to be subtracted.
+     * @param resultUnit unit of returned pressure.
+     * @return a new pressure containing result.
+     */
+    public Pressure subtractAndReturnNew(
+            final double value, final PressureUnit unit, final PressureUnit resultUnit) {
+        final var result = new Pressure();
+        result.setUnit(resultUnit);
+        result.setValue(subtract(getValue().doubleValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Subtracts provided pressure value and unit and returns a new pressure instance using
+     * provided unit.
+     *
+     * @param value      value to be subtracted.
+     * @param unit       unit of value to be subtracted.
+     * @param resultUnit unit of returned pressure.
+     * @return a new pressure containing result.
+     */
+    public Pressure subtractAndReturnNew(
+            final Number value, final PressureUnit unit, final PressureUnit resultUnit) {
+        final var result = new Pressure();
+        result.setUnit(resultUnit);
+        result.setValue(subtract(getValue(), getUnit(), value, unit, resultUnit));
+        return result;
+    }
+
+    /**
+     * Subtracts provided pressure to current instance and returns a new pressure instance.
+     *
+     * @param p    pressure to be subtracted.
+     * @param unit unit of returned pressure.
+     * @return a new pressure containing result.
+     */
+    public Pressure subtractAndReturnNew(final Pressure p, final PressureUnit unit) {
+        return subtractAndReturnNew(this, p, unit);
+    }
+
+    /**
+     * Subtracts provided pressure value and unit and updates current pressure instance.
+     *
+     * @param value pressure value to be subtracted.
+     * @param unit  unit of pressure value.
+     */
+    public void subtract(final double value, final PressureUnit unit) {
+        setValue(subtract(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Subtracts provided pressure value and unit and updates current pressure instance.
+     *
+     * @param value pressure value to be subtracted.
+     * @param unit  unit of pressure value.
+     */
+    public void subtract(final Number value, final PressureUnit unit) {
+        setValue(subtract(getValue(), getUnit(), value, unit, getUnit()));
+    }
+
+    /**
+     * Subtracts provided pressure and updates current pressure.
+     *
+     * @param pressure pressure to be subtracted.
+     */
+    public void subtract(final Pressure pressure) {
+        subtract(this, pressure, this);
+    }
+
+    /**
+     * Subtracts provided pressure and stores the result into provided pressure.
+     *
+     * @param p      pressure to be subtracted.
+     * @param result instance where result will be stored.
+     */
+    public void subtract(final Pressure p, final Pressure result) {
+        subtract(this, p, result);
+    }
+}

--- a/src/main/java/com/irurueta/units/PressureConverter.java
+++ b/src/main/java/com/irurueta/units/PressureConverter.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.math.BigDecimal;
+
+/**
+ * Does pressure conversions to different units.
+ * To prevent loss of accuracy, conversion should only be done as a final step
+ * before displaying pressure measurements.
+ */
+@SuppressWarnings("WeakerAccess")
+public class PressureConverter {
+
+    /**
+     * Number of pascals in 1 kilopascal.
+     */
+    static final double PASCALS_PER_KILOPASCAL = 1000.0;
+
+    /**
+     * Number of pascals in 1 bar.
+     */
+    static final double PASCALS_PER_BAR = 100000.0;
+
+    /**
+     * Number of pascals in 1 atmosphere.
+     */
+    static final double PASCALS_PER_ATMOSPHERE = 101325.0;
+
+    /**
+     * Number of pascals in 1 psi.
+     */
+    static final double PASCALS_PER_PSI = 6894.757293168;
+
+    /**
+     * Constructor.
+     * Prevents instantiation of helper class.
+     */
+    private PressureConverter() {
+    }
+
+    /**
+     * Converts a pressure instance to provided output pressure unit.
+     *
+     * @param input  input pressure to be converted.
+     * @param output output pressure where result will be stored containing output unit.
+     */
+    public static void convert(final Pressure input, final Pressure output) {
+        convert(input, output.getUnit(), output);
+    }
+
+    /**
+     * Converts a pressure instance to requested output unit.
+     *
+     * @param input      input pressure to be converted.
+     * @param outputUnit requested output unit.
+     * @return converted pressure.
+     */
+    public static Pressure convertAndReturnNew(
+            final Pressure input, final PressureUnit outputUnit) {
+        final var result = new Pressure();
+        convert(input, outputUnit, result);
+        return result;
+    }
+
+    /**
+     * Converts and updates a pressure to requested output unit.
+     *
+     * @param pressure   input pressure to be converted and updated.
+     * @param outputUnit requested output unit.
+     */
+    public static void convert(final Pressure pressure, final PressureUnit outputUnit) {
+        convert(pressure, outputUnit, pressure);
+    }
+
+    /**
+     * Converts a pressure to requested output unit.
+     *
+     * @param input      input pressure to be converted.
+     * @param outputUnit requested output unit.
+     * @param result     pressure instance where result will be stored.
+     */
+    public static void convert(
+            final Pressure input, final PressureUnit outputUnit, final Pressure result) {
+        final var value = convert(input.getValue(), input.getUnit(), outputUnit);
+        result.setValue(value);
+        result.setUnit(outputUnit);
+    }
+
+    /**
+     * Converts a pressure value from input unit to provided output unit.
+     *
+     * @param input      pressure value.
+     * @param inputUnit  input pressure unit.
+     * @param outputUnit output pressure unit.
+     * @return converted pressure value.
+     */
+    public static Number convert(final Number input, final PressureUnit inputUnit, final PressureUnit outputUnit) {
+        return BigDecimal.valueOf(convert(input.doubleValue(), inputUnit, outputUnit));
+    }
+
+    /**
+     * Converts a pressure value from input unit to provided output unit.
+     *
+     * @param input      pressure value.
+     * @param inputUnit  input pressure unit.
+     * @param outputUnit output pressure unit.
+     * @return converted pressure value.
+     */
+    public static double convert(final double input, final PressureUnit inputUnit, final PressureUnit outputUnit) {
+        //convert to pascals
+        final var pascals = switch (inputUnit) {
+            case KILOPASCAL -> kilopascalToPascal(input);
+            case BAR -> barToPascal(input);
+            case ATMOSPHERE -> atmosphereToPascal(input);
+            case PSI -> psiToPascal(input);
+            default -> input;
+        };
+
+        //convert from pascals to required output unit
+        return switch (outputUnit) {
+            case KILOPASCAL -> pascalToKilopascal(pascals);
+            case BAR -> pascalToBar(pascals);
+            case ATMOSPHERE -> pascalToAtmosphere(pascals);
+            case PSI -> pascalToPsi(pascals);
+            default -> pascals;
+        };
+    }
+
+    /**
+     * Converts provided kilopascal value to pascals.
+     *
+     * @param kilopascal kilopascal value.
+     * @return same pressure converted to pascals.
+     */
+    public static double kilopascalToPascal(final double kilopascal) {
+        return kilopascal * PASCALS_PER_KILOPASCAL;
+    }
+
+    /**
+     * Converts provided pascal value to kilopascal.
+     *
+     * @param pascal pascal value.
+     * @return same pressure converted to kilopascal.
+     */
+    public static double pascalToKilopascal(final double pascal) {
+        return pascal / PASCALS_PER_KILOPASCAL;
+    }
+
+    /**
+     * Converts provided bar value to pascals.
+     *
+     * @param bar bar value.
+     * @return same pressure converted to pascals.
+     */
+    public static double barToPascal(final double bar) {
+        return bar * PASCALS_PER_BAR;
+    }
+
+    /**
+     * Converts provided pascal value to bar.
+     *
+     * @param pascal pascal value.
+     * @return same pressure converted to bar.
+     */
+    public static double pascalToBar(final double pascal) {
+        return pascal / PASCALS_PER_BAR;
+    }
+
+    /**
+     * Converts provided atmosphere value to pascals.
+     *
+     * @param atmosphere atmosphere value.
+     * @return same pressure converted to pascals.
+     */
+    public static double atmosphereToPascal(final double atmosphere) {
+        return atmosphere * PASCALS_PER_ATMOSPHERE;
+    }
+
+    /**
+     * Converts provided pascal value to atmosphere.
+     *
+     * @param pascal pascal value.
+     * @return same pressure converted to atmosphere.
+     */
+    public static double pascalToAtmosphere(final double pascal) {
+        return pascal / PASCALS_PER_ATMOSPHERE;
+    }
+
+    /**
+     * Converts provided psi value to pascals.
+     *
+     * @param psi psi value.
+     * @return same pressure converted to pascals.
+     */
+    public static double psiToPascal(final double psi) {
+        return psi * PASCALS_PER_PSI;
+    }
+
+    /**
+     * Converts provided pascal value to psi.
+     *
+     * @param pascal pascal value.
+     * @return same pressure converted to psi.
+     */
+    public static double pascalToPsi(final double pascal) {
+        return pascal / PASCALS_PER_PSI;
+    }
+}

--- a/src/main/java/com/irurueta/units/PressureFormatter.java
+++ b/src/main/java/com/irurueta/units/PressureFormatter.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import java.text.ParseException;
+import java.util.Locale;
+
+/**
+ * Formats and parses pressure value and unit.
+ */
+public class PressureFormatter extends MeasureFormatter<Pressure, PressureUnit> {
+
+    /**
+     * Pascal symbol.
+     */
+    public static final String PASCAL = "Pa";
+
+    /**
+     * Kilopascal symbol.
+     */
+    public static final String KILOPASCAL = "kPa";
+
+    /**
+     * Bar symbol.
+     */
+    public static final String BAR = "bar";
+
+    /**
+     * Atmosphere symbol.
+     */
+    public static final String ATMOSPHERE = "atm";
+
+    /**
+     * Psi symbol.
+     */
+    public static final String PSI = "psi";
+
+    /**
+     * Constructor.
+     */
+    public PressureFormatter() {
+        super();
+    }
+
+    /**
+     * Constructor with locale.
+     *
+     * @param locale locale.
+     * @throws IllegalArgumentException if locale is null.
+     */
+    public PressureFormatter(final Locale locale) {
+        super(locale);
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param formatter input instance to copy from.
+     * @throws NullPointerException if provided formatter is null.
+     */
+    public PressureFormatter(final PressureFormatter formatter) {
+        this(formatter.getLocale());
+    }
+
+    /**
+     * Determines if two pressure formatters are equal by comparing all of their internal
+     * parameters.
+     *
+     * @param obj another object to compare.
+     * @return true if provided object is assumed to be equal to this instance.
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        final var equals = super.equals(obj);
+        return (obj instanceof PressureFormatter) && equals;
+    }
+
+    /**
+     * Hash code generated for this instance.
+     * Hash codes can be internally used by some collections to coarsely compare objects.
+     * This implementation only calls parent implementation to avoid static analyzer warning.
+     *
+     * @return hash code.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * Gets unit system for detected unit into provided string representation
+     * of a measurement.
+     *
+     * @param source a measurement string representation to be checked.
+     * @return a unit system (either metric or imperial) or null if unit
+     * cannot be determined.
+     */
+    @Override
+    public UnitSystem getUnitSystem(final String source) {
+        final var unit = findUnit(source);
+        return unit != null ? PressureUnit.getUnitSystem(unit) : null;
+    }
+
+    /**
+     * Parses provided string and tries to determine pressure value and unit.
+     *
+     * @param source a string to be parsed.
+     * @return a pressure containing a value and unit.
+     * @throws ParseException       if provided string cannot be parsed.
+     * @throws UnknownUnitException if unit cannot be determined.
+     */
+    @Override
+    public Pressure parse(final String source) throws ParseException, UnknownUnitException {
+        return internalParse(source, new Pressure());
+    }
+
+    /**
+     * Attempts to determine a pressure unit within a measurement string representation.
+     *
+     * @param source a measurement string representation.
+     * @return a pressure unit, or null if none can be determined.
+     */
+    @Override
+    public PressureUnit findUnit(final String source) {
+        if (source.contains(KILOPASCAL + " ") || source.endsWith(KILOPASCAL)) {
+            return PressureUnit.KILOPASCAL;
+        }
+        if (source.contains(ATMOSPHERE + " ") || source.endsWith(ATMOSPHERE)) {
+            return PressureUnit.ATMOSPHERE;
+        }
+        if (source.contains(BAR + " ") || source.endsWith(BAR)) {
+            return PressureUnit.BAR;
+        }
+        if (source.contains(PSI + " ") || source.endsWith(PSI)) {
+            return PressureUnit.PSI;
+        }
+        if (source.contains(PASCAL + " ") || source.endsWith(PASCAL)) {
+            return PressureUnit.PASCAL;
+        }
+        return null;
+    }
+
+    /**
+     * Formats and converts provided pressure value and unit using provided
+     * unit system.
+     * If provided value is too large for provided unit, this method will
+     * convert it to a more appropriate unit using provided unit system (either
+     * metric or imperial).
+     *
+     * @param value  a pressure value.
+     * @param unit   a pressure unit.
+     * @param system system unit to convert pressure to.
+     * @return a string representation of pressure value and unit.
+     */
+    @Override
+    public String formatAndConvert(final Number value, final PressureUnit unit, final UnitSystem system) {
+        if (system == UnitSystem.IMPERIAL) {
+            return formatAndConvertImperial(value, unit);
+        } else {
+            return formatAndConvertMetric(value, unit);
+        }
+    }
+
+    /**
+     * Formats and converts provided pressure value and unit using metric unit system.
+     *
+     * @param value a pressure value.
+     * @param unit  a pressure unit.
+     * @return a string representation of pressure value and unit using metric unit system.
+     */
+    public String formatAndConvertMetric(final Number value, final PressureUnit unit) {
+        //always format as pascals
+        return format(PressureConverter.convert(value, unit, PressureUnit.PASCAL), PressureUnit.PASCAL);
+    }
+
+    /**
+     * Formats and converts provided pressure value and unit using imperial unit system.
+     *
+     * @param value a pressure value.
+     * @param unit  a pressure unit.
+     * @return a string representation of pressure value and unit using imperial unit system.
+     */
+    public String formatAndConvertImperial(final Number value, final PressureUnit unit) {
+        //always format as psi
+        return format(PressureConverter.convert(value, unit, PressureUnit.PSI), PressureUnit.PSI);
+    }
+
+    /**
+     * Returns unit string representation.
+     *
+     * @param unit a pressure unit.
+     * @return its string representation.
+     */
+    @Override
+    public String getUnitSymbol(final PressureUnit unit) {
+        return switch (unit) {
+            case KILOPASCAL -> KILOPASCAL;
+            case BAR -> BAR;
+            case ATMOSPHERE -> ATMOSPHERE;
+            case PSI -> PSI;
+            default -> PASCAL;
+        };
+    }
+}

--- a/src/main/java/com/irurueta/units/PressureUnit.java
+++ b/src/main/java/com/irurueta/units/PressureUnit.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+/**
+ * Enumerator containing recognized typical pressure units.
+ */
+public enum PressureUnit {
+    /**
+     * Pascal (Pa).
+     */
+    PASCAL,
+
+    /**
+     * Kilopascal (kPa).
+     */
+    KILOPASCAL,
+
+    /**
+     * Bar (bar).
+     */
+    BAR,
+
+    /**
+     * Atmosphere (atm).
+     */
+    ATMOSPHERE,
+
+    /**
+     * Pound-force per square inch (psi).
+     */
+    PSI;
+
+    /**
+     * Returns unit system for provided pressure unit.
+     *
+     * @param unit pressure unit to be checked.
+     * @return unit system (metric or imperial).
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static UnitSystem getUnitSystem(final PressureUnit unit) {
+        if (unit == null) {
+            throw new IllegalArgumentException();
+        }
+
+        return switch (unit) {
+            case PSI -> UnitSystem.IMPERIAL;
+            default -> UnitSystem.METRIC;
+        };
+    }
+
+    /**
+     * Gets all supported metric pressure units.
+     *
+     * @return all supported metric pressure units.
+     */
+    public static PressureUnit[] getMetricUnits() {
+        return new PressureUnit[]{
+                PASCAL,
+                KILOPASCAL,
+                BAR,
+                ATMOSPHERE
+        };
+    }
+
+    /**
+     * Gets all supported imperial pressure units.
+     *
+     * @return all supported imperial pressure units.
+     */
+    public static PressureUnit[] getImperialUnits() {
+        return new PressureUnit[]{
+                PSI
+        };
+    }
+
+    /**
+     * Indicates whether provided unit belongs to the metric unit system.
+     *
+     * @param unit pressure unit to be checked.
+     * @return true if unit belongs to metric unit system.
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static boolean isMetric(final PressureUnit unit) {
+        return getUnitSystem(unit) == UnitSystem.METRIC;
+    }
+
+    /**
+     * Indicates whether provided unit belongs to the imperial unit system.
+     *
+     * @param unit pressure unit to be checked.
+     * @return true if unit belongs to imperial unit system.
+     * @throws IllegalArgumentException if unit is null or not supported.
+     */
+    public static boolean isImperial(final PressureUnit unit) {
+        return getUnitSystem(unit) == UnitSystem.IMPERIAL;
+    }
+}

--- a/src/main/java/com/irurueta/units/package-info.java
+++ b/src/main/java/com/irurueta/units/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Performs distance and surface unit conversion and formatting.
+ * Performs distance, surface, force, pressure, energy and power unit conversion and formatting.
  */
 package com.irurueta.units;

--- a/src/test/java/com/irurueta/units/EnergyConverterTest.java
+++ b/src/test/java/com/irurueta/units/EnergyConverterTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnergyConverterTest {
+
+    private static final double JOULES_PER_KILOJOULE = 1000.0;
+    private static final double JOULES_PER_CALORIE = 4.184;
+    private static final double JOULES_PER_KILOCALORIE = 4184.0;
+    private static final double JOULES_PER_KILOWATT_HOUR = 3600000.0;
+    private static final double JOULES_PER_BTU = 1055.05585262;
+
+    private static final double ERROR = 1e-6;
+
+    /**
+     * Converts provided value expressed in provided unit into joules, using locally
+     * re-declared conversion factors, independent from the ones used internally by
+     * {@link EnergyConverter}.
+     *
+     * @param value value to be converted.
+     * @param unit  unit of provided value.
+     * @return value converted to joules.
+     */
+    private static double toJoules(final double value, final EnergyUnit unit) {
+        return switch (unit) {
+            case KILOJOULE -> value * JOULES_PER_KILOJOULE;
+            case CALORIE -> value * JOULES_PER_CALORIE;
+            case KILOCALORIE -> value * JOULES_PER_KILOCALORIE;
+            case KILOWATT_HOUR -> value * JOULES_PER_KILOWATT_HOUR;
+            case BTU -> value * JOULES_PER_BTU;
+            default -> value;
+        };
+    }
+
+    /**
+     * Converts provided value expressed in joules into provided unit, using locally
+     * re-declared conversion factors, independent from the ones used internally by
+     * {@link EnergyConverter}.
+     *
+     * @param joules value expressed in joules.
+     * @param unit   unit to convert to.
+     * @return value converted to provided unit.
+     */
+    private static double fromJoules(final double joules, final EnergyUnit unit) {
+        return switch (unit) {
+            case KILOJOULE -> joules / JOULES_PER_KILOJOULE;
+            case CALORIE -> joules / JOULES_PER_CALORIE;
+            case KILOCALORIE -> joules / JOULES_PER_KILOCALORIE;
+            case KILOWATT_HOUR -> joules / JOULES_PER_KILOWATT_HOUR;
+            case BTU -> joules / JOULES_PER_BTU;
+            default -> joules;
+        };
+    }
+
+    @Test
+    void testJouleKilojoule() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * JOULES_PER_KILOJOULE, EnergyConverter.kilojouleToJoule(inputValue), ERROR);
+        assertEquals(inputValue / JOULES_PER_KILOJOULE, EnergyConverter.jouleToKilojoule(inputValue), ERROR);
+    }
+
+    @Test
+    void testJouleCalorie() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * JOULES_PER_CALORIE, EnergyConverter.calorieToJoule(inputValue), ERROR);
+        assertEquals(inputValue / JOULES_PER_CALORIE, EnergyConverter.jouleToCalorie(inputValue), ERROR);
+    }
+
+    @Test
+    void testJouleKilocalorie() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * JOULES_PER_KILOCALORIE, EnergyConverter.kilocalorieToJoule(inputValue), ERROR);
+        assertEquals(inputValue / JOULES_PER_KILOCALORIE, EnergyConverter.jouleToKilocalorie(inputValue), ERROR);
+    }
+
+    @Test
+    void testJouleKilowattHour() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * JOULES_PER_KILOWATT_HOUR, EnergyConverter.kilowattHourToJoule(inputValue),
+                ERROR);
+        assertEquals(inputValue / JOULES_PER_KILOWATT_HOUR, EnergyConverter.jouleToKilowattHour(inputValue),
+                ERROR);
+    }
+
+    @Test
+    void testJouleBtu() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * JOULES_PER_BTU, EnergyConverter.btuToJoule(inputValue), ERROR);
+        assertEquals(inputValue / JOULES_PER_BTU, EnergyConverter.jouleToBtu(inputValue), ERROR);
+    }
+
+    @Test
+    void testConvertDouble() {
+        final var inputValue = new Random().nextDouble();
+
+        for (final var inputUnit : EnergyUnit.values()) {
+            for (final var outputUnit : EnergyUnit.values()) {
+                final var expected = fromJoules(toJoules(inputValue, inputUnit), outputUnit);
+                assertEquals(expected, EnergyConverter.convert(inputValue, inputUnit, outputUnit), ERROR);
+            }
+        }
+    }
+
+    @Test
+    void testConvertNumber() {
+        final var inputValue = BigDecimal.valueOf(new Random().nextDouble());
+
+        assertEquals(inputValue.doubleValue(),
+                EnergyConverter.convert(inputValue, EnergyUnit.JOULE, EnergyUnit.JOULE).doubleValue(),
+                ERROR);
+    }
+
+    @Test
+    void testConvertEnergy() {
+        final var value = new Random().nextDouble();
+        final var inputEnergy = new Energy(value, EnergyUnit.JOULE);
+
+        final var outputEnergy = new Energy();
+        EnergyConverter.convert(inputEnergy, EnergyUnit.KILOJOULE, outputEnergy);
+
+        // check
+        assertEquals(value, inputEnergy.getValue().doubleValue(), 0.0);
+        assertEquals(EnergyUnit.JOULE, inputEnergy.getUnit());
+
+        assertEquals(EnergyUnit.KILOJOULE, outputEnergy.getUnit());
+        assertEquals(EnergyConverter.convert(value, inputEnergy.getUnit(), outputEnergy.getUnit()),
+                outputEnergy.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertAndUpdateEnergy() {
+        final var value = new Random().nextDouble();
+        final var energy = new Energy(value, EnergyUnit.JOULE);
+
+        EnergyConverter.convert(energy, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyUnit.KILOJOULE, energy.getUnit());
+        assertEquals(EnergyConverter.convert(value, EnergyUnit.JOULE, EnergyUnit.KILOJOULE),
+                energy.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertAndReturnNewEnergy() {
+        final var value = new Random().nextDouble();
+        final var inputEnergy = new Energy(value, EnergyUnit.JOULE);
+
+        final var outputEnergy = EnergyConverter.convertAndReturnNew(inputEnergy, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(value, inputEnergy.getValue().doubleValue(), 0.0);
+        assertEquals(EnergyUnit.JOULE, inputEnergy.getUnit());
+
+        assertEquals(EnergyUnit.KILOJOULE, outputEnergy.getUnit());
+        assertEquals(EnergyConverter.convert(value, inputEnergy.getUnit(), outputEnergy.getUnit()),
+                outputEnergy.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertToOutputEnergyUnit() {
+        final var value = new Random().nextDouble();
+        final var inputEnergy = new Energy(value, EnergyUnit.JOULE);
+
+        final var outputEnergy = new Energy();
+        outputEnergy.setUnit(EnergyUnit.KILOJOULE);
+        EnergyConverter.convert(inputEnergy, outputEnergy);
+
+        // check
+        assertEquals(value, inputEnergy.getValue().doubleValue(), 0.0);
+        assertEquals(EnergyUnit.JOULE, inputEnergy.getUnit());
+
+        assertEquals(EnergyUnit.KILOJOULE, outputEnergy.getUnit());
+        assertEquals(EnergyConverter.convert(value, inputEnergy.getUnit(),
+                outputEnergy.getUnit()), outputEnergy.getValue().doubleValue(), 0.0);
+    }
+}

--- a/src/test/java/com/irurueta/units/EnergyFormatterTest.java
+++ b/src/test/java/com/irurueta/units/EnergyFormatterTest.java
@@ -1,0 +1,802 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.FieldPosition;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnergyFormatterTest {
+
+    private static final double JOULES_PER_KILOJOULE = 1000.0;
+    private static final double JOULES_PER_BTU = 1055.05585262;
+
+    @Test
+    void testConstructor() {
+        // test empty constructor
+        var formatter = new EnergyFormatter();
+
+        // check
+        assertEquals(Locale.getDefault(), formatter.getLocale());
+        assertEquals(NumberFormat.getInstance().getMaximumFractionDigits(), formatter.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance().getMaximumIntegerDigits(), formatter.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance().getMinimumFractionDigits(), formatter.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance().getMinimumIntegerDigits(), formatter.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance().getRoundingMode(), formatter.getRoundingMode());
+        assertEquals(UnitLocale.getDefault(), formatter.getUnitSystem());
+        assertEquals(NumberFormat.getInstance().isGroupingUsed(), formatter.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance().isParseIntegerOnly(), formatter.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // test constructor with locale
+        final var locale = new Locale("es", "ES");
+        formatter = new EnergyFormatter(locale);
+
+        // check
+        assertEquals(locale, formatter.getLocale());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumFractionDigits(), formatter.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumIntegerDigits(), formatter.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumFractionDigits(), formatter.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumIntegerDigits(), formatter.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getRoundingMode(), formatter.getRoundingMode());
+        assertEquals(UnitLocale.getFrom(locale), formatter.getUnitSystem());
+        assertEquals(NumberFormat.getInstance(locale).isGroupingUsed(), formatter.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance(locale).isParseIntegerOnly(), formatter.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> new EnergyFormatter((Locale) null));
+
+        // test copy constructor
+        formatter = new EnergyFormatter(locale);
+        final var formatter2 = new EnergyFormatter(formatter);
+
+        // check
+        assertEquals(locale, formatter2.getLocale());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumFractionDigits(),
+                formatter2.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumIntegerDigits(), formatter2.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumFractionDigits(),
+                formatter2.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumIntegerDigits(), formatter2.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getRoundingMode(), formatter2.getRoundingMode());
+        assertEquals(UnitLocale.getFrom(locale), formatter2.getUnitSystem());
+        assertEquals(NumberFormat.getInstance(locale).isGroupingUsed(), formatter2.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance(locale).isParseIntegerOnly(), formatter2.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter2.getValueAndUnitFormatPattern());
+
+        //noinspection DataFlowIssue
+        assertThrows(NullPointerException.class, () -> new EnergyFormatter((EnergyFormatter) null));
+    }
+
+    @Test
+    void testClone() throws CloneNotSupportedException {
+        final var formatter1 = new EnergyFormatter();
+        final var formatter2 = (EnergyFormatter) formatter1.clone();
+
+        // check
+        assertNotSame(formatter1, formatter2);
+        assertEquals(formatter1, formatter2);
+
+        // test after initializing internal number format
+        assertNotNull(formatter1.format(0.5, EnergyUnit.JOULE, new StringBuffer(), new FieldPosition(0)));
+        final var formatter3 = (EnergyFormatter) formatter1.clone();
+
+        assertNotSame(formatter1, formatter3);
+        assertEquals(formatter1, formatter3);
+    }
+
+    @Test
+    void testEquals() {
+        final var formatter1 = new EnergyFormatter(Locale.ENGLISH);
+        final var formatter2 = new EnergyFormatter(Locale.ENGLISH);
+        final var formatter3 = new EnergyFormatter(Locale.FRENCH);
+
+        // check
+        //noinspection EqualsWithItself
+        assertEquals(formatter1, formatter1);
+        assertEquals(formatter1, formatter2);
+        assertNotEquals(formatter1, formatter3);
+
+        assertNotEquals(formatter1, new Object());
+
+        assertNotEquals(null, formatter1);
+    }
+
+    @Test
+    void testHashCode() {
+        final var formatter1 = new EnergyFormatter(Locale.ENGLISH);
+        final var formatter2 = new EnergyFormatter(Locale.ENGLISH);
+        final var formatter3 = new EnergyFormatter(Locale.FRENCH);
+
+        assertEquals(formatter1.hashCode(), formatter1.hashCode());
+        assertEquals(formatter1.hashCode(), formatter2.hashCode());
+        assertNotEquals(formatter1.hashCode(), formatter3.hashCode());
+    }
+
+    @Test
+    void testFormatNumber() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new EnergyFormatter(l);
+
+        assertEquals("5,5 J", formatter.format(new BigDecimal(value), EnergyUnit.JOULE));
+        assertEquals("5,5 kJ", formatter.format(new BigDecimal(value), EnergyUnit.KILOJOULE));
+        assertEquals("5,5 cal", formatter.format(new BigDecimal(value), EnergyUnit.CALORIE));
+        assertEquals("5,5 kcal", formatter.format(new BigDecimal(value), EnergyUnit.KILOCALORIE));
+        assertEquals("5,5 kWh", formatter.format(new BigDecimal(value), EnergyUnit.KILOWATT_HOUR));
+        assertEquals("5,5 BTU", formatter.format(new BigDecimal(value), EnergyUnit.BTU));
+    }
+
+    @Test
+    void testFormatNumberAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new EnergyFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 J", formatter.format(new BigDecimal(value), EnergyUnit.JOULE, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kJ", formatter.format(new BigDecimal(value), EnergyUnit.KILOJOULE, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 cal", formatter.format(new BigDecimal(value), EnergyUnit.CALORIE, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kcal", formatter.format(new BigDecimal(value), EnergyUnit.KILOCALORIE, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kWh", formatter.format(new BigDecimal(value), EnergyUnit.KILOWATT_HOUR, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 BTU", formatter.format(new BigDecimal(value), EnergyUnit.BTU, buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatDouble() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new EnergyFormatter(l);
+
+        assertEquals("5,5 J", formatter.format(value, EnergyUnit.JOULE));
+        assertEquals("5,5 kJ", formatter.format(value, EnergyUnit.KILOJOULE));
+        assertEquals("5,5 cal", formatter.format(value, EnergyUnit.CALORIE));
+        assertEquals("5,5 kcal", formatter.format(value, EnergyUnit.KILOCALORIE));
+        assertEquals("5,5 kWh", formatter.format(value, EnergyUnit.KILOWATT_HOUR));
+        assertEquals("5,5 BTU", formatter.format(value, EnergyUnit.BTU));
+    }
+
+    @Test
+    void testFormatDoubleAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new EnergyFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 J", formatter.format(value, EnergyUnit.JOULE, buffer, new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kJ", formatter.format(value, EnergyUnit.KILOJOULE, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 cal", formatter.format(value, EnergyUnit.CALORIE, buffer, new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kcal", formatter.format(value, EnergyUnit.KILOCALORIE, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kWh", formatter.format(value, EnergyUnit.KILOWATT_HOUR, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 BTU", formatter.format(value, EnergyUnit.BTU, buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatEnergy() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new EnergyFormatter(l);
+
+        assertEquals("5,5 J", formatter.format(new Energy(value, EnergyUnit.JOULE)));
+        assertEquals("5,5 kJ", formatter.format(new Energy(value, EnergyUnit.KILOJOULE)));
+        assertEquals("5,5 cal", formatter.format(new Energy(value, EnergyUnit.CALORIE)));
+        assertEquals("5,5 kcal", formatter.format(new Energy(value, EnergyUnit.KILOCALORIE)));
+        assertEquals("5,5 kWh", formatter.format(new Energy(value, EnergyUnit.KILOWATT_HOUR)));
+        assertEquals("5,5 BTU", formatter.format(new Energy(value, EnergyUnit.BTU)));
+    }
+
+    @Test
+    void testFormatEnergyAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new EnergyFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 J", formatter.format(new Energy(value, EnergyUnit.JOULE), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kJ", formatter.format(new Energy(value, EnergyUnit.KILOJOULE), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 cal", formatter.format(new Energy(value, EnergyUnit.CALORIE), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kcal", formatter.format(new Energy(value, EnergyUnit.KILOCALORIE), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kWh", formatter.format(new Energy(value, EnergyUnit.KILOWATT_HOUR), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 BTU", formatter.format(new Energy(value, EnergyUnit.BTU), buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatAndConvertNumber() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.JOULE),
+                formatter.formatAndConvert(new BigDecimal("5.5"), EnergyUnit.JOULE));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE, EnergyUnit.JOULE),
+                formatter.formatAndConvert(new BigDecimal("1.0"), EnergyUnit.KILOJOULE));
+        assertEquals(formatter.format(5.5 * JOULES_PER_BTU, EnergyUnit.JOULE),
+                formatter.formatAndConvert(new BigDecimal("5.5"), EnergyUnit.BTU));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.BTU),
+                formatter.formatAndConvert(new BigDecimal("5.5"), EnergyUnit.BTU));
+    }
+
+    @Test
+    void testFormatAndConvertDouble() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.JOULE),
+                formatter.formatAndConvert(5.5, EnergyUnit.JOULE));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE, EnergyUnit.JOULE),
+                formatter.formatAndConvert(1.0, EnergyUnit.KILOJOULE));
+        assertEquals(formatter.format(5.5 * JOULES_PER_BTU, EnergyUnit.JOULE),
+                formatter.formatAndConvert(5.5, EnergyUnit.BTU));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.BTU),
+                formatter.formatAndConvert(5.5, EnergyUnit.BTU));
+    }
+
+    @Test
+    void testFormatAndConvertEnergy() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.JOULE),
+                formatter.formatAndConvert(new Energy(5.5, EnergyUnit.JOULE)));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE, EnergyUnit.JOULE),
+                formatter.formatAndConvert(new Energy(1.0, EnergyUnit.KILOJOULE)));
+        assertEquals(formatter.format(5.5 * JOULES_PER_BTU, EnergyUnit.JOULE),
+                formatter.formatAndConvert(new Energy(5.5, EnergyUnit.BTU)));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.BTU),
+                formatter.formatAndConvert(new Energy(5.5, EnergyUnit.BTU)));
+    }
+
+    @Test
+    void testFormatAndConvertNumberAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.JOULE), formatter.formatAndConvert(
+                new BigDecimal("5.5"), EnergyUnit.JOULE, UnitSystem.METRIC));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE, EnergyUnit.JOULE), formatter.formatAndConvert(
+                new BigDecimal("1.0"), EnergyUnit.KILOJOULE, UnitSystem.METRIC));
+
+        assertEquals(formatter.format(5.5 * JOULES_PER_BTU, EnergyUnit.JOULE), formatter.formatAndConvert(
+                new BigDecimal("5.5"), EnergyUnit.BTU, UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.BTU), formatter.formatAndConvert(
+                new BigDecimal("5.5"), EnergyUnit.BTU, UnitSystem.IMPERIAL));
+
+        assertEquals(formatter.format(5.5 / JOULES_PER_BTU, EnergyUnit.BTU), formatter.formatAndConvert(
+                new BigDecimal("5.5"), EnergyUnit.JOULE, UnitSystem.IMPERIAL));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE / JOULES_PER_BTU, EnergyUnit.BTU),
+                formatter.formatAndConvert(new BigDecimal("1.0"), EnergyUnit.KILOJOULE, UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertDoubleAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.JOULE), formatter.formatAndConvert(
+                5.5, EnergyUnit.JOULE, UnitSystem.METRIC));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE, EnergyUnit.JOULE), formatter.formatAndConvert(
+                1.0, EnergyUnit.KILOJOULE, UnitSystem.METRIC));
+
+        assertEquals(formatter.format(5.5 * JOULES_PER_BTU, EnergyUnit.JOULE), formatter.formatAndConvert(
+                5.5, EnergyUnit.BTU, UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.BTU), formatter.formatAndConvert(
+                5.5, EnergyUnit.BTU, UnitSystem.IMPERIAL));
+
+        assertEquals(formatter.format(5.5 / JOULES_PER_BTU, EnergyUnit.BTU), formatter.formatAndConvert(
+                5.5, EnergyUnit.JOULE, UnitSystem.IMPERIAL));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE / JOULES_PER_BTU, EnergyUnit.BTU),
+                formatter.formatAndConvert(1.0, EnergyUnit.KILOJOULE, UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertEnergyAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.JOULE), formatter.formatAndConvert(
+                new Energy(5.5, EnergyUnit.JOULE), UnitSystem.METRIC));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE, EnergyUnit.JOULE), formatter.formatAndConvert(
+                new Energy(1.0, EnergyUnit.KILOJOULE), UnitSystem.METRIC));
+
+        assertEquals(formatter.format(5.5 * JOULES_PER_BTU, EnergyUnit.JOULE), formatter.formatAndConvert(
+                new Energy(5.5, EnergyUnit.BTU), UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.BTU), formatter.formatAndConvert(
+                new Energy(5.5, EnergyUnit.BTU), UnitSystem.IMPERIAL));
+
+        assertEquals(formatter.format(5.5 / JOULES_PER_BTU, EnergyUnit.BTU), formatter.formatAndConvert(
+                new Energy(5.5, EnergyUnit.JOULE), UnitSystem.IMPERIAL));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE / JOULES_PER_BTU, EnergyUnit.BTU),
+                formatter.formatAndConvert(new Energy(1.0, EnergyUnit.KILOJOULE), UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertMetric() {
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.JOULE),
+                formatter.formatAndConvertMetric(new BigDecimal("5.5"), EnergyUnit.JOULE));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE, EnergyUnit.JOULE),
+                formatter.formatAndConvertMetric(new BigDecimal("1.0"), EnergyUnit.KILOJOULE));
+        assertEquals(formatter.format(5.5 * JOULES_PER_BTU, EnergyUnit.JOULE),
+                formatter.formatAndConvertMetric(new BigDecimal("5.5"), EnergyUnit.BTU));
+    }
+
+    @Test
+    void testFormatAndConvertImperial() {
+        final var l = new Locale("en", "US");
+
+        final var formatter = new EnergyFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, EnergyUnit.BTU),
+                formatter.formatAndConvertImperial(new BigDecimal("5.5"), EnergyUnit.BTU));
+
+        assertEquals(formatter.format(5.5 / JOULES_PER_BTU, EnergyUnit.BTU),
+                formatter.formatAndConvertImperial(new BigDecimal("5.5"), EnergyUnit.JOULE));
+        assertEquals(formatter.format(1.0 * JOULES_PER_KILOJOULE / JOULES_PER_BTU, EnergyUnit.BTU),
+                formatter.formatAndConvertImperial(new BigDecimal("1.0"), EnergyUnit.KILOJOULE));
+    }
+
+    @Test
+    void testGetAvailableLocales() {
+        final var locales = EnergyFormatter.getAvailableLocales();
+        assertArrayEquals(locales, NumberFormat.getAvailableLocales());
+    }
+
+    @Test
+    void testGetSetMaximumFractionDigits() {
+        final var formatter = new EnergyFormatter();
+
+        assertEquals(formatter.getMaximumFractionDigits(), NumberFormat.getInstance().getMaximumFractionDigits());
+
+        // set new value
+        formatter.setMaximumFractionDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMaximumFractionDigits());
+    }
+
+    @Test
+    void testGetSetMaximumIntegerDigits() {
+        final var formatter = new EnergyFormatter();
+
+        assertEquals(formatter.getMaximumIntegerDigits(), NumberFormat.getInstance().getMaximumIntegerDigits());
+
+        // set new value
+        formatter.setMaximumIntegerDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMaximumIntegerDigits());
+    }
+
+    @Test
+    void testGetSetMinimumFractionDigits() {
+        final var formatter = new EnergyFormatter();
+
+        assertEquals(formatter.getMinimumFractionDigits(), NumberFormat.getInstance().getMinimumFractionDigits());
+
+        // set new value
+        formatter.setMinimumFractionDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMinimumFractionDigits());
+    }
+
+    @Test
+    void testGetSetMinimumIntegerDigits() {
+        final var formatter = new EnergyFormatter();
+
+        assertEquals(formatter.getMinimumIntegerDigits(), NumberFormat.getInstance().getMinimumIntegerDigits());
+
+        // set new value
+        formatter.setMinimumIntegerDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMinimumIntegerDigits());
+    }
+
+    @Test
+    void testGetSetRoundingMode() {
+        final var formatter = new EnergyFormatter();
+
+        assertEquals(formatter.getRoundingMode(), NumberFormat.getInstance().getRoundingMode());
+
+        // set new value
+        formatter.setRoundingMode(RoundingMode.UNNECESSARY);
+
+        // check correctness
+        assertEquals(RoundingMode.UNNECESSARY, formatter.getRoundingMode());
+    }
+
+    @Test
+    void testIsSetGroupingUsed() {
+        final var formatter = new EnergyFormatter();
+
+        assertEquals(formatter.isGroupingUsed(), NumberFormat.getInstance().isGroupingUsed());
+
+        // set new value
+        formatter.setGroupingUsed(!formatter.isGroupingUsed());
+
+        // check correctness
+        assertEquals(formatter.isGroupingUsed(), !NumberFormat.getInstance().isGroupingUsed());
+    }
+
+    @Test
+    void testIsSetParseIntegerOnly() {
+        final var formatter = new EnergyFormatter();
+
+        assertEquals(formatter.isParseIntegerOnly(), NumberFormat.getInstance().isParseIntegerOnly());
+
+        // set new value
+        formatter.setParseIntegerOnly(!formatter.isParseIntegerOnly());
+
+        // check correctness
+        assertEquals(formatter.isParseIntegerOnly(), !NumberFormat.getInstance().isParseIntegerOnly());
+    }
+
+    @Test
+    void testGetSetValueAndUnitFormatPattern() {
+        final var formatter = new EnergyFormatter();
+
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // new value
+        formatter.setValueAndUnitFormatPattern("{0}{1}");
+
+        // check correctness
+        assertEquals("{0}{1}", formatter.getValueAndUnitFormatPattern());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> formatter.setValueAndUnitFormatPattern(null));
+    }
+
+    @Test
+    void testGetUnitSystem() {
+        var formatter = new EnergyFormatter(new Locale("es", "ES"));
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem());
+
+        formatter = new EnergyFormatter(new Locale("en", "US"));
+        assertEquals(UnitSystem.IMPERIAL, formatter.getUnitSystem());
+    }
+
+    @Test
+    void testIsValidUnit() {
+        final var formatter = new EnergyFormatter();
+
+        assertTrue(formatter.isValidUnit("J"));
+        assertTrue(formatter.isValidUnit("J "));
+
+        assertTrue(formatter.isValidUnit("kJ"));
+        assertTrue(formatter.isValidUnit("kJ "));
+
+        assertTrue(formatter.isValidUnit("cal"));
+        assertTrue(formatter.isValidUnit("cal "));
+
+        assertTrue(formatter.isValidUnit("kcal"));
+        assertTrue(formatter.isValidUnit("kcal "));
+
+        assertTrue(formatter.isValidUnit("kWh"));
+        assertTrue(formatter.isValidUnit("kWh "));
+
+        assertTrue(formatter.isValidUnit("BTU"));
+        assertTrue(formatter.isValidUnit("BTU "));
+    }
+
+    @Test
+    void testIsValidMeasurement() {
+        final var formatter = new EnergyFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 J";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 kJ";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 cal";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 kcal";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 kWh";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 BTU";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isValidMeasurement(text));
+
+        text = "m";
+        assertFalse(formatter.isValidMeasurement(text));
+    }
+
+    @Test
+    void testIsMetricUnit() {
+        final var formatter = new EnergyFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 J";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 kJ";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 cal";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 kcal";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 kWh";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 BTU";
+        assertFalse(formatter.isMetricUnit(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isMetricUnit(text));
+    }
+
+    @Test
+    void testIsImperialUnit() {
+        final var formatter = new EnergyFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 J";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 kJ";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 cal";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 kcal";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 kWh";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 BTU";
+        assertTrue(formatter.isImperialUnit(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isImperialUnit(text));
+    }
+
+    @Test
+    void testGetUnitSystemFromSource() {
+        final var formatter = new EnergyFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 J";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 kJ";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 cal";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 kcal";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 kWh";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 BTU";
+        assertEquals(UnitSystem.IMPERIAL, formatter.getUnitSystem(text));
+
+        text = "5,5 s";
+        assertNull(formatter.getUnitSystem(text));
+    }
+
+    @Test
+    void testParse() throws ParseException, UnknownUnitException {
+        final var formatter = new EnergyFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 J";
+        var e = formatter.parse(text);
+        assertEquals(5.5, e.getValue().doubleValue(), 0.0);
+        assertEquals(EnergyUnit.JOULE, e.getUnit());
+
+        text = "5,5 kJ";
+        e = formatter.parse(text);
+        assertEquals(5.5, e.getValue().doubleValue(), 0.0);
+        assertEquals(EnergyUnit.KILOJOULE, e.getUnit());
+
+        text = "5,5 cal";
+        e = formatter.parse(text);
+        assertEquals(5.5, e.getValue().doubleValue(), 0.0);
+        assertEquals(EnergyUnit.CALORIE, e.getUnit());
+
+        text = "5,5 kcal";
+        e = formatter.parse(text);
+        assertEquals(5.5, e.getValue().doubleValue(), 0.0);
+        assertEquals(EnergyUnit.KILOCALORIE, e.getUnit());
+
+        text = "5,5 kWh";
+        e = formatter.parse(text);
+        assertEquals(5.5, e.getValue().doubleValue(), 0.0);
+        assertEquals(EnergyUnit.KILOWATT_HOUR, e.getUnit());
+
+        text = "5,5 BTU";
+        e = formatter.parse(text);
+        assertEquals(5.5, e.getValue().doubleValue(), 0.0);
+        assertEquals(EnergyUnit.BTU, e.getUnit());
+
+        // Force UnknownUnitException
+        assertThrows(UnknownUnitException.class, () -> formatter.parse("5,5 s"));
+
+        // Force ParseException
+        assertThrows(ParseException.class, () -> formatter.parse("m"));
+    }
+
+    @Test
+    void testFindUnit() {
+        final var formatter = new EnergyFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 J";
+        assertEquals(EnergyUnit.JOULE, formatter.findUnit(text));
+
+        text = "5,5 kJ";
+        assertEquals(EnergyUnit.KILOJOULE, formatter.findUnit(text));
+
+        text = "5,5 cal";
+        assertEquals(EnergyUnit.CALORIE, formatter.findUnit(text));
+
+        text = "5,5 kcal";
+        assertEquals(EnergyUnit.KILOCALORIE, formatter.findUnit(text));
+
+        text = "5,5 kWh";
+        assertEquals(EnergyUnit.KILOWATT_HOUR, formatter.findUnit(text));
+
+        text = "5,5 BTU";
+        assertEquals(EnergyUnit.BTU, formatter.findUnit(text));
+
+        text = "5,5 s";
+        assertNull(formatter.findUnit(text));
+    }
+
+    @Test
+    void testGetUnitSymbol() {
+        final var formatter = new EnergyFormatter();
+
+        assertEquals(EnergyFormatter.JOULE, formatter.getUnitSymbol(EnergyUnit.JOULE));
+        assertEquals(EnergyFormatter.KILOJOULE, formatter.getUnitSymbol(EnergyUnit.KILOJOULE));
+        assertEquals(EnergyFormatter.CALORIE, formatter.getUnitSymbol(EnergyUnit.CALORIE));
+        assertEquals(EnergyFormatter.KILOCALORIE, formatter.getUnitSymbol(EnergyUnit.KILOCALORIE));
+        assertEquals(EnergyFormatter.KILOWATT_HOUR, formatter.getUnitSymbol(EnergyUnit.KILOWATT_HOUR));
+        assertEquals(EnergyFormatter.BTU, formatter.getUnitSymbol(EnergyUnit.BTU));
+    }
+}

--- a/src/test/java/com/irurueta/units/EnergyTest.java
+++ b/src/test/java/com/irurueta/units/EnergyTest.java
@@ -1,0 +1,568 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnergyTest {
+
+    private static final double ERROR = 1e-6;
+
+    @Test
+    void testConstructor() {
+        // test empty constructor
+        var e = new Energy();
+
+        // check
+        assertNull(e.getValue());
+        assertNull(e.getUnit());
+
+        // test constructor with value and unit
+        e = new Energy(323, EnergyUnit.JOULE);
+
+        // check
+        assertEquals(323, e.getValue());
+        assertEquals(EnergyUnit.JOULE, e.getUnit());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> new Energy(null, EnergyUnit.JOULE));
+        assertThrows(IllegalArgumentException.class, () -> new Energy(323, null));
+    }
+
+    @Test
+    void testEquals() {
+        final var value = new Random().nextDouble();
+        final var e1 = new Energy(value, EnergyUnit.JOULE);
+        final var e2 = new Energy(value, EnergyUnit.JOULE);
+        final var e3 = new Energy(value + 1.0, EnergyUnit.JOULE);
+        final var e4 = new Energy(value, EnergyUnit.KILOJOULE);
+
+        //noinspection EqualsWithItself
+        assertEquals(e1, e1);
+        assertEquals(e1, e2);
+        assertNotEquals(e1, e3);
+        assertNotEquals(e1, e4);
+
+        assertNotEquals(null, e1);
+        assertNotEquals(e1, new Object());
+    }
+
+    @Test
+    void tetHashCode() {
+        final var value = new Random().nextDouble();
+        final var e1 = new Energy(value, EnergyUnit.JOULE);
+        final var e2 = new Energy(value, EnergyUnit.JOULE);
+        final var e3 = new Energy(value + 1.0, EnergyUnit.JOULE);
+        final var e4 = new Energy(value, EnergyUnit.KILOJOULE);
+
+        assertEquals(e1.hashCode(), e1.hashCode());
+        assertEquals(e1.hashCode(), e2.hashCode());
+        assertNotEquals(e1.hashCode(), e3.hashCode());
+        assertNotEquals(e1.hashCode(), e4.hashCode());
+    }
+
+    @Test
+    void testEqualsWithTolerance() {
+        final var value = new Random().nextDouble();
+        final var e1 = new Energy(value, EnergyUnit.JOULE);
+        final var e2 = new Energy(value, EnergyUnit.JOULE);
+        final var e3 = new Energy(value + 0.5 * ERROR, EnergyUnit.JOULE);
+        final var e4 = new Energy(value, EnergyUnit.KILOJOULE);
+        final var e5 = new Energy(EnergyConverter.convert(value, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), EnergyUnit.KILOJOULE);
+
+        assertTrue(e1.equals(e1, 0.0));
+        assertTrue(e1.equals(e2, 0.0));
+        assertFalse(e1.equals(e3, 0.0));
+        assertTrue(e1.equals(e3, ERROR));
+        assertFalse(e1.equals(e4, ERROR));
+        assertTrue(e1.equals(e5, ERROR));
+
+        assertFalse(e1.equals(null, ERROR));
+    }
+
+    @Test
+    void testGetSetValue() {
+        final var e = new Energy(1, EnergyUnit.JOULE);
+
+        // check
+        assertEquals(1, e.getValue());
+
+        // set new value
+        e.setValue(2.5);
+
+        // check
+        assertEquals(2.5, e.getValue());
+
+        //force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> e.setValue(null));
+    }
+
+    @Test
+    void testGetSetUnit() {
+        final var e = new Energy(1, EnergyUnit.JOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e.getUnit());
+
+        // set new value
+        e.setUnit(EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyUnit.KILOJOULE, e.getUnit());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> e.setUnit(null));
+    }
+
+    @Test
+    void testAdd1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Energy.add(value1, EnergyUnit.JOULE, value2,
+                EnergyUnit.JOULE, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyConverter.convert(value1 + value2, EnergyUnit.JOULE,
+                        EnergyUnit.KILOJOULE), result, ERROR);
+    }
+
+    @Test
+    void testAdd2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Energy.add(new BigDecimal(value1), EnergyUnit.JOULE,
+                new BigDecimal(value2), EnergyUnit.JOULE, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyConverter.convert(value1 + value2, EnergyUnit.JOULE,
+                        EnergyUnit.KILOJOULE), result.doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+        final var e2 = new Energy(value2, EnergyUnit.JOULE);
+
+        final var result = new Energy(0.0, EnergyUnit.KILOJOULE);
+        Energy.add(e1, e2, result);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.JOULE, e2.getUnit());
+        assertEquals(value2, e2.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 + value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+        final var e2 = new Energy(value2, EnergyUnit.JOULE);
+
+        final var result = Energy.addAndReturnNew(e1, e2, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.JOULE, e2.getUnit());
+        assertEquals(value2, e2.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 + value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+
+        final var result = e1.addAndReturnNew(value2, EnergyUnit.JOULE, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 + value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+
+        final var result = e1.addAndReturnNew(new BigDecimal(value2), EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 + value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+        final var e2 = new Energy(value2, EnergyUnit.JOULE);
+
+        final var result = e1.addAndReturnNew(e2, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.JOULE, e2.getUnit());
+        assertEquals(e2.getValue().doubleValue(), value2, 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 + value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+
+        e1.add(value2, EnergyUnit.JOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1 + value2, e1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd5() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+
+        e1.add(new BigDecimal(value2), EnergyUnit.JOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1 + value2, e1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd6() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+        final var e2 = new Energy(value2, EnergyUnit.JOULE);
+
+        e1.add(e2);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1 + value2, e1.getValue().doubleValue(), ERROR);
+
+        assertEquals(EnergyUnit.JOULE, e2.getUnit());
+        assertEquals(value2, e2.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testAdd7() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+        final var e2 = new Energy(value2, EnergyUnit.JOULE);
+
+        final var result = new Energy(0.0, EnergyUnit.KILOJOULE);
+        e1.add(e2, result);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.JOULE, e2.getUnit());
+        assertEquals(value2, e2.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 + value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Energy.subtract(value1, EnergyUnit.JOULE, value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyConverter.convert(value1 - value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result, ERROR);
+    }
+
+    @Test
+    void testSubtract2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Energy.subtract(new BigDecimal(value1), EnergyUnit.JOULE, new BigDecimal(value2),
+                EnergyUnit.JOULE, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyConverter.convert(value1 - value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+        final var e2 = new Energy(value2, EnergyUnit.JOULE);
+
+        final var result = new Energy(0.0, EnergyUnit.KILOJOULE);
+        Energy.subtract(e1, e2, result);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.JOULE, e2.getUnit());
+        assertEquals(value2, e2.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 - value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+        final var e2 = new Energy(value2, EnergyUnit.JOULE);
+
+        final var result = Energy.subtractAndReturnNew(e1, e2, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.JOULE, e2.getUnit());
+        assertEquals(value2, e2.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 - value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+
+        final var result = e1.subtractAndReturnNew(value2, EnergyUnit.JOULE, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 - value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+
+        final var result = e1.subtractAndReturnNew(new BigDecimal(value2), EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 - value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+        final var e2 = new Energy(value2, EnergyUnit.JOULE);
+
+        final var result = e1.subtractAndReturnNew(e2, EnergyUnit.KILOJOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.JOULE, e2.getUnit());
+        assertEquals(value2, e2.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 - value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+
+        e1.subtract(value2, EnergyUnit.JOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1 - value2, e1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract5() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+
+        e1.subtract(new BigDecimal(value2), EnergyUnit.JOULE);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1 - value2, e1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract6() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+        final var e2 = new Energy(value2, EnergyUnit.JOULE);
+
+        e1.subtract(e2);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1 - value2, e1.getValue().doubleValue(), ERROR);
+
+        assertEquals(EnergyUnit.JOULE, e2.getUnit());
+        assertEquals(value2, e2.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testSubtract7() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var e1 = new Energy(value1, EnergyUnit.JOULE);
+        final var e2 = new Energy(value2, EnergyUnit.JOULE);
+
+        final var result = new Energy(0.0, EnergyUnit.KILOJOULE);
+        e1.subtract(e2, result);
+
+        // check
+        assertEquals(EnergyUnit.JOULE, e1.getUnit());
+        assertEquals(value1, e1.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.JOULE, e2.getUnit());
+        assertEquals(value2, e2.getValue().doubleValue(), 0.0);
+
+        assertEquals(EnergyUnit.KILOJOULE, result.getUnit());
+        assertEquals(EnergyConverter.convert(value1 - value2, EnergyUnit.JOULE,
+                EnergyUnit.KILOJOULE), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSerializeDeserialize() throws IOException, ClassNotFoundException {
+        final var value = new Random().nextDouble();
+        final var e1 = new Energy(value, EnergyUnit.JOULE);
+
+        final var bytes = SerializationHelper.serialize(e1);
+        final var e2 = SerializationHelper.deserialize(bytes);
+
+        assertEquals(e1, e2);
+        assertNotSame(e1, e2);
+    }
+}

--- a/src/test/java/com/irurueta/units/EnergyUnitTest.java
+++ b/src/test/java/com/irurueta/units/EnergyUnitTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnergyUnitTest {
+
+    @Test
+    void testGetUnitSystem() {
+        assertEquals(UnitSystem.METRIC, EnergyUnit.getUnitSystem(EnergyUnit.JOULE));
+        assertEquals(UnitSystem.METRIC, EnergyUnit.getUnitSystem(EnergyUnit.KILOJOULE));
+        assertEquals(UnitSystem.METRIC, EnergyUnit.getUnitSystem(EnergyUnit.CALORIE));
+        assertEquals(UnitSystem.METRIC, EnergyUnit.getUnitSystem(EnergyUnit.KILOCALORIE));
+        assertEquals(UnitSystem.METRIC, EnergyUnit.getUnitSystem(EnergyUnit.KILOWATT_HOUR));
+        assertEquals(UnitSystem.IMPERIAL, EnergyUnit.getUnitSystem(EnergyUnit.BTU));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> EnergyUnit.getUnitSystem(null));
+    }
+
+    @Test
+    void testGetMetricUnits() {
+        final var metricUnits = EnergyUnit.getMetricUnits();
+        final var imperialUnits = EnergyUnit.getImperialUnits();
+
+        for (final var metricUnit : metricUnits) {
+            assertTrue(EnergyUnit.isMetric(metricUnit));
+            assertFalse(EnergyUnit.isImperial(metricUnit));
+        }
+
+        assertEquals(metricUnits.length + imperialUnits.length, EnergyUnit.values().length);
+    }
+
+    @Test
+    void testGetImperialUnits() {
+        final var metricUnits = EnergyUnit.getMetricUnits();
+        final var imperialUnits = EnergyUnit.getImperialUnits();
+
+        for (final var imperialUnit : imperialUnits) {
+            assertTrue(EnergyUnit.isImperial(imperialUnit));
+            assertFalse(EnergyUnit.isMetric(imperialUnit));
+        }
+
+        assertEquals(metricUnits.length + imperialUnits.length, EnergyUnit.values().length);
+    }
+
+    @Test
+    void testIsMetric() {
+        assertTrue(EnergyUnit.isMetric(EnergyUnit.JOULE));
+        assertTrue(EnergyUnit.isMetric(EnergyUnit.KILOJOULE));
+        assertTrue(EnergyUnit.isMetric(EnergyUnit.CALORIE));
+        assertTrue(EnergyUnit.isMetric(EnergyUnit.KILOCALORIE));
+        assertTrue(EnergyUnit.isMetric(EnergyUnit.KILOWATT_HOUR));
+        assertFalse(EnergyUnit.isMetric(EnergyUnit.BTU));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> EnergyUnit.isMetric(null));
+    }
+
+    @Test
+    void testIsImperial() {
+        assertFalse(EnergyUnit.isImperial(EnergyUnit.JOULE));
+        assertFalse(EnergyUnit.isImperial(EnergyUnit.KILOJOULE));
+        assertFalse(EnergyUnit.isImperial(EnergyUnit.CALORIE));
+        assertFalse(EnergyUnit.isImperial(EnergyUnit.KILOCALORIE));
+        assertFalse(EnergyUnit.isImperial(EnergyUnit.KILOWATT_HOUR));
+        assertTrue(EnergyUnit.isImperial(EnergyUnit.BTU));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> EnergyUnit.isImperial(null));
+    }
+}

--- a/src/test/java/com/irurueta/units/ForceConverterTest.java
+++ b/src/test/java/com/irurueta/units/ForceConverterTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ForceConverterTest {
+
+    private static final double NEWTONS_PER_POUND_FORCE = 4.4482216152605;
+    private static final double NEWTONS_PER_DYNE = 0.00001;
+    private static final double NEWTONS_PER_KILOGRAM_FORCE = 9.80665;
+    private static final double NEWTONS_PER_KILONEWTON = 1000.0;
+
+    private static final double ERROR = 1e-6;
+
+    /**
+     * Converts provided value expressed in provided unit into newtons, using locally
+     * re-declared conversion factors, independent from the ones used internally by
+     * {@link ForceConverter}.
+     *
+     * @param value value to be converted.
+     * @param unit  unit of provided value.
+     * @return value converted to newtons.
+     */
+    private static double toNewtons(final double value, final ForceUnit unit) {
+        return switch (unit) {
+            case POUND_FORCE -> value * NEWTONS_PER_POUND_FORCE;
+            case DYNE -> value * NEWTONS_PER_DYNE;
+            case KILOGRAM_FORCE -> value * NEWTONS_PER_KILOGRAM_FORCE;
+            case KILONEWTON -> value * NEWTONS_PER_KILONEWTON;
+            default -> value;
+        };
+    }
+
+    /**
+     * Converts provided value expressed in newtons into provided unit, using locally
+     * re-declared conversion factors, independent from the ones used internally by
+     * {@link ForceConverter}.
+     *
+     * @param newtons value expressed in newtons.
+     * @param unit    unit to convert to.
+     * @return value converted to provided unit.
+     */
+    private static double fromNewtons(final double newtons, final ForceUnit unit) {
+        return switch (unit) {
+            case POUND_FORCE -> newtons / NEWTONS_PER_POUND_FORCE;
+            case DYNE -> newtons / NEWTONS_PER_DYNE;
+            case KILOGRAM_FORCE -> newtons / NEWTONS_PER_KILOGRAM_FORCE;
+            case KILONEWTON -> newtons / NEWTONS_PER_KILONEWTON;
+            default -> newtons;
+        };
+    }
+
+    @Test
+    void testNewtonPoundForce() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * NEWTONS_PER_POUND_FORCE, ForceConverter.poundForceToNewton(inputValue), ERROR);
+        assertEquals(inputValue / NEWTONS_PER_POUND_FORCE, ForceConverter.newtonToPoundForce(inputValue), ERROR);
+    }
+
+    @Test
+    void testNewtonDyne() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * NEWTONS_PER_DYNE, ForceConverter.dyneToNewton(inputValue), ERROR);
+        assertEquals(inputValue / NEWTONS_PER_DYNE, ForceConverter.newtonToDyne(inputValue), ERROR);
+    }
+
+    @Test
+    void testNewtonKilogramForce() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * NEWTONS_PER_KILOGRAM_FORCE, ForceConverter.kilogramForceToNewton(inputValue),
+                ERROR);
+        assertEquals(inputValue / NEWTONS_PER_KILOGRAM_FORCE, ForceConverter.newtonToKilogramForce(inputValue),
+                ERROR);
+    }
+
+    @Test
+    void testNewtonKilonewton() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * NEWTONS_PER_KILONEWTON, ForceConverter.kilonewtonToNewton(inputValue), ERROR);
+        assertEquals(inputValue / NEWTONS_PER_KILONEWTON, ForceConverter.newtonToKilonewton(inputValue), ERROR);
+    }
+
+    @Test
+    void testConvertDouble() {
+        final var inputValue = new Random().nextDouble();
+
+        for (final var inputUnit : ForceUnit.values()) {
+            for (final var outputUnit : ForceUnit.values()) {
+                final var expected = fromNewtons(toNewtons(inputValue, inputUnit), outputUnit);
+                assertEquals(expected, ForceConverter.convert(inputValue, inputUnit, outputUnit), ERROR);
+            }
+        }
+    }
+
+    @Test
+    void testConvertNumber() {
+        final var inputValue = BigDecimal.valueOf(new Random().nextDouble());
+
+        assertEquals(inputValue.doubleValue(),
+                ForceConverter.convert(inputValue, ForceUnit.NEWTON, ForceUnit.NEWTON).doubleValue(), ERROR);
+    }
+
+    @Test
+    void testConvertForce() {
+        final var value = new Random().nextDouble();
+        final var inputForce = new Force(value, ForceUnit.NEWTON);
+
+        final var outputForce = new Force();
+        ForceConverter.convert(inputForce, ForceUnit.KILONEWTON, outputForce);
+
+        // check
+        assertEquals(value, inputForce.getValue().doubleValue(), 0.0);
+        assertEquals(ForceUnit.NEWTON, inputForce.getUnit());
+
+        assertEquals(ForceUnit.KILONEWTON, outputForce.getUnit());
+        assertEquals(ForceConverter.convert(value, inputForce.getUnit(), outputForce.getUnit()),
+                outputForce.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertAndUpdateForce() {
+        final var value = new Random().nextDouble();
+        final var force = new Force(value, ForceUnit.NEWTON);
+
+        ForceConverter.convert(force, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceUnit.KILONEWTON, force.getUnit());
+        assertEquals(ForceConverter.convert(value, ForceUnit.NEWTON, ForceUnit.KILONEWTON),
+                force.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertAndReturnNewForce() {
+        final var value = new Random().nextDouble();
+        final var inputForce = new Force(value, ForceUnit.NEWTON);
+
+        final var outputForce = ForceConverter.convertAndReturnNew(inputForce, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(value, inputForce.getValue().doubleValue(), 0.0);
+        assertEquals(ForceUnit.NEWTON, inputForce.getUnit());
+
+        assertEquals(ForceUnit.KILONEWTON, outputForce.getUnit());
+        assertEquals(ForceConverter.convert(value, inputForce.getUnit(), outputForce.getUnit()),
+                outputForce.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertToOutputForceUnit() {
+        final var value = new Random().nextDouble();
+        final var inputForce = new Force(value, ForceUnit.NEWTON);
+
+        final var outputForce = new Force();
+        outputForce.setUnit(ForceUnit.KILONEWTON);
+        ForceConverter.convert(inputForce, outputForce);
+
+        // check
+        assertEquals(value, inputForce.getValue().doubleValue(), 0.0);
+        assertEquals(ForceUnit.NEWTON, inputForce.getUnit());
+
+        assertEquals(ForceUnit.KILONEWTON, outputForce.getUnit());
+        assertEquals(ForceConverter.convert(value, inputForce.getUnit(),
+                outputForce.getUnit()), outputForce.getValue().doubleValue(), 0.0);
+    }
+}

--- a/src/test/java/com/irurueta/units/ForceFormatterTest.java
+++ b/src/test/java/com/irurueta/units/ForceFormatterTest.java
@@ -1,0 +1,740 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.FieldPosition;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ForceFormatterTest {
+
+    @Test
+    void testConstructor() {
+        // test empty constructor
+        var formatter = new ForceFormatter();
+
+        // check
+        assertEquals(Locale.getDefault(), formatter.getLocale());
+        assertEquals(NumberFormat.getInstance().getMaximumFractionDigits(), formatter.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance().getMaximumIntegerDigits(), formatter.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance().getMinimumFractionDigits(), formatter.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance().getMinimumIntegerDigits(), formatter.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance().getRoundingMode(), formatter.getRoundingMode());
+        assertEquals(UnitLocale.getDefault(), formatter.getUnitSystem());
+        assertEquals(NumberFormat.getInstance().isGroupingUsed(), formatter.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance().isParseIntegerOnly(), formatter.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // test constructor with locale
+        final var locale = new Locale("es", "ES");
+        formatter = new ForceFormatter(locale);
+
+        // check
+        assertEquals(locale, formatter.getLocale());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumFractionDigits(), formatter.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumIntegerDigits(), formatter.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumFractionDigits(), formatter.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumIntegerDigits(), formatter.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getRoundingMode(), formatter.getRoundingMode());
+        assertEquals(UnitLocale.getFrom(locale), formatter.getUnitSystem());
+        assertEquals(NumberFormat.getInstance(locale).isGroupingUsed(), formatter.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance(locale).isParseIntegerOnly(), formatter.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> new ForceFormatter((Locale) null));
+
+        // test copy constructor
+        formatter = new ForceFormatter(locale);
+        final var formatter2 = new ForceFormatter(formatter);
+
+        // check
+        assertEquals(locale, formatter2.getLocale());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumFractionDigits(),
+                formatter2.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumIntegerDigits(), formatter2.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumFractionDigits(),
+                formatter2.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumIntegerDigits(), formatter2.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getRoundingMode(), formatter2.getRoundingMode());
+        assertEquals(UnitLocale.getFrom(locale), formatter2.getUnitSystem());
+        assertEquals(NumberFormat.getInstance(locale).isGroupingUsed(), formatter2.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance(locale).isParseIntegerOnly(), formatter2.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter2.getValueAndUnitFormatPattern());
+
+        //noinspection DataFlowIssue
+        assertThrows(NullPointerException.class, () -> new ForceFormatter((ForceFormatter) null));
+    }
+
+    @Test
+    void testClone() throws CloneNotSupportedException {
+        final var formatter1 = new ForceFormatter();
+        final var formatter2 = (ForceFormatter) formatter1.clone();
+
+        // check
+        assertNotSame(formatter1, formatter2);
+        assertEquals(formatter1, formatter2);
+
+        // test after initializing internal number format
+        assertNotNull(formatter1.format(0.5, ForceUnit.NEWTON, new StringBuffer(), new FieldPosition(0)));
+        final var formatter3 = (ForceFormatter) formatter1.clone();
+
+        assertNotSame(formatter1, formatter3);
+        assertEquals(formatter1, formatter3);
+    }
+
+    @Test
+    void testEquals() {
+        final var formatter1 = new ForceFormatter(Locale.ENGLISH);
+        final var formatter2 = new ForceFormatter(Locale.ENGLISH);
+        final var formatter3 = new ForceFormatter(Locale.FRENCH);
+
+        // check
+        //noinspection EqualsWithItself
+        assertEquals(formatter1, formatter1);
+        assertEquals(formatter1, formatter2);
+        assertNotEquals(formatter1, formatter3);
+
+        assertNotEquals(formatter1, new Object());
+
+        assertNotEquals(null, formatter1);
+    }
+
+    @Test
+    void testHashCode() {
+        final var formatter1 = new ForceFormatter(Locale.ENGLISH);
+        final var formatter2 = new ForceFormatter(Locale.ENGLISH);
+        final var formatter3 = new ForceFormatter(Locale.FRENCH);
+
+        assertEquals(formatter1.hashCode(), formatter1.hashCode());
+        assertEquals(formatter1.hashCode(), formatter2.hashCode());
+        assertNotEquals(formatter1.hashCode(), formatter3.hashCode());
+    }
+
+    @Test
+    void testFormatNumber() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new ForceFormatter(l);
+
+        assertEquals("5,5 N", formatter.format(new BigDecimal(value), ForceUnit.NEWTON));
+        assertEquals("5,5 kN", formatter.format(new BigDecimal(value), ForceUnit.KILONEWTON));
+        assertEquals("5,5 lbf", formatter.format(new BigDecimal(value), ForceUnit.POUND_FORCE));
+        assertEquals("5,5 dyn", formatter.format(new BigDecimal(value), ForceUnit.DYNE));
+        assertEquals("5,5 kgf", formatter.format(new BigDecimal(value), ForceUnit.KILOGRAM_FORCE));
+    }
+
+    @Test
+    void testFormatNumberAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new ForceFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 N", formatter.format(new BigDecimal(value), ForceUnit.NEWTON, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kN", formatter.format(new BigDecimal(value), ForceUnit.KILONEWTON, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 lbf", formatter.format(new BigDecimal(value), ForceUnit.POUND_FORCE, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 dyn", formatter.format(new BigDecimal(value), ForceUnit.DYNE, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kgf", formatter.format(new BigDecimal(value), ForceUnit.KILOGRAM_FORCE, buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatDouble() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new ForceFormatter(l);
+
+        assertEquals("5,5 N", formatter.format(value, ForceUnit.NEWTON));
+        assertEquals("5,5 kN", formatter.format(value, ForceUnit.KILONEWTON));
+        assertEquals("5,5 lbf", formatter.format(value, ForceUnit.POUND_FORCE));
+        assertEquals("5,5 dyn", formatter.format(value, ForceUnit.DYNE));
+        assertEquals("5,5 kgf", formatter.format(value, ForceUnit.KILOGRAM_FORCE));
+    }
+
+    @Test
+    void testFormatDoubleAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new ForceFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 N", formatter.format(value, ForceUnit.NEWTON, buffer, new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kN", formatter.format(value, ForceUnit.KILONEWTON, buffer, new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 lbf", formatter.format(value, ForceUnit.POUND_FORCE, buffer, new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 dyn", formatter.format(value, ForceUnit.DYNE, buffer, new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kgf", formatter.format(value, ForceUnit.KILOGRAM_FORCE, buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatForce() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new ForceFormatter(l);
+
+        assertEquals("5,5 N", formatter.format(new Force(value, ForceUnit.NEWTON)));
+        assertEquals("5,5 kN", formatter.format(new Force(value, ForceUnit.KILONEWTON)));
+        assertEquals("5,5 lbf", formatter.format(new Force(value, ForceUnit.POUND_FORCE)));
+        assertEquals("5,5 dyn", formatter.format(new Force(value, ForceUnit.DYNE)));
+        assertEquals("5,5 kgf", formatter.format(new Force(value, ForceUnit.KILOGRAM_FORCE)));
+    }
+
+    @Test
+    void testFormatForceAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new ForceFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 N", formatter.format(new Force(value, ForceUnit.NEWTON), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kN", formatter.format(new Force(value, ForceUnit.KILONEWTON), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 lbf", formatter.format(new Force(value, ForceUnit.POUND_FORCE), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 dyn", formatter.format(new Force(value, ForceUnit.DYNE), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kgf", formatter.format(new Force(value, ForceUnit.KILOGRAM_FORCE), buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatAndConvertNumber() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5,5 N", formatter.formatAndConvert(new BigDecimal("5.5"), ForceUnit.NEWTON));
+        assertEquals("9,81 N", formatter.formatAndConvert(new BigDecimal(1), ForceUnit.KILOGRAM_FORCE));
+        assertEquals("24,47 N", formatter.formatAndConvert(new BigDecimal("5.5"), ForceUnit.POUND_FORCE));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5.5 lbf", formatter.formatAndConvert(new BigDecimal("5.5"), ForceUnit.POUND_FORCE));
+    }
+
+    @Test
+    void testFormatAndConvertDouble() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5,5 N", formatter.formatAndConvert(5.5, ForceUnit.NEWTON));
+        assertEquals("9,81 N", formatter.formatAndConvert(1.0, ForceUnit.KILOGRAM_FORCE));
+        assertEquals("24,47 N", formatter.formatAndConvert(5.5, ForceUnit.POUND_FORCE));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5.5 lbf", formatter.formatAndConvert(5.5, ForceUnit.POUND_FORCE));
+    }
+
+    @Test
+    void testFormatAndConvertForce() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5,5 N", formatter.formatAndConvert(new Force(5.5, ForceUnit.NEWTON)));
+        assertEquals("9,81 N", formatter.formatAndConvert(new Force(1.0, ForceUnit.KILOGRAM_FORCE)));
+        assertEquals("24,47 N", formatter.formatAndConvert(new Force(5.5, ForceUnit.POUND_FORCE)));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5.5 lbf", formatter.formatAndConvert(new Force(5.5, ForceUnit.POUND_FORCE)));
+    }
+
+    @Test
+    void testFormatAndConvertNumberAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5,5 N", formatter.formatAndConvert(new BigDecimal("5.5"),
+                ForceUnit.NEWTON, UnitSystem.METRIC));
+        assertEquals("9,81 N", formatter.formatAndConvert(new BigDecimal("1.0"),
+                ForceUnit.KILOGRAM_FORCE, UnitSystem.METRIC));
+
+        assertEquals("24,47 N", formatter.formatAndConvert(new BigDecimal("5.5"),
+                ForceUnit.POUND_FORCE, UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5.5 lbf", formatter.formatAndConvert(new BigDecimal("5.5"),
+                ForceUnit.POUND_FORCE, UnitSystem.IMPERIAL));
+
+        assertEquals("1.24 lbf", formatter.formatAndConvert(new BigDecimal("5.5"),
+                ForceUnit.NEWTON, UnitSystem.IMPERIAL));
+        assertEquals("2.2 lbf", formatter.formatAndConvert(new BigDecimal("1.0"), ForceUnit.KILOGRAM_FORCE,
+                UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertDoubleAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5,5 N", formatter.formatAndConvert(5.5,
+                ForceUnit.NEWTON, UnitSystem.METRIC));
+        assertEquals("9,81 N", formatter.formatAndConvert(1.0, ForceUnit.KILOGRAM_FORCE,
+                UnitSystem.METRIC));
+
+        assertEquals("24,47 N", formatter.formatAndConvert(5.5,
+                ForceUnit.POUND_FORCE, UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5.5 lbf", formatter.formatAndConvert(5.5,
+                ForceUnit.POUND_FORCE, UnitSystem.IMPERIAL));
+
+        assertEquals("1.24 lbf", formatter.formatAndConvert(5.5,
+                ForceUnit.NEWTON, UnitSystem.IMPERIAL));
+        assertEquals("2.2 lbf", formatter.formatAndConvert(1.0, ForceUnit.KILOGRAM_FORCE,
+                UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertForceAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5,5 N", formatter.formatAndConvert(new Force(5.5,
+                ForceUnit.NEWTON), UnitSystem.METRIC));
+        assertEquals("9,81 N", formatter.formatAndConvert(new Force(1.0, ForceUnit.KILOGRAM_FORCE),
+                UnitSystem.METRIC));
+
+        assertEquals("24,47 N", formatter.formatAndConvert(new Force(5.5,
+                ForceUnit.POUND_FORCE), UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5.5 lbf", formatter.formatAndConvert(new Force(5.5,
+                ForceUnit.POUND_FORCE), UnitSystem.IMPERIAL));
+
+        assertEquals("1.24 lbf", formatter.formatAndConvert(new Force(5.5,
+                ForceUnit.NEWTON), UnitSystem.IMPERIAL));
+        assertEquals("2.2 lbf", formatter.formatAndConvert(new Force(1.0, ForceUnit.KILOGRAM_FORCE),
+                UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertMetric() {
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5,5 N", formatter.formatAndConvertMetric(new BigDecimal("5.5"), ForceUnit.NEWTON));
+        assertEquals("9,81 N", formatter.formatAndConvertMetric(new BigDecimal("1.0"), ForceUnit.KILOGRAM_FORCE));
+        assertEquals("24,47 N", formatter.formatAndConvertMetric(new BigDecimal("5.5"), ForceUnit.POUND_FORCE));
+    }
+
+    @Test
+    void testFormatAndConvertImperial() {
+        final var l = new Locale("en", "US");
+
+        final var formatter = new ForceFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals("5.5 lbf", formatter.formatAndConvertImperial(new BigDecimal("5.5"), ForceUnit.POUND_FORCE));
+
+        assertEquals("1.24 lbf", formatter.formatAndConvertImperial(new BigDecimal("5.5"), ForceUnit.NEWTON));
+        assertEquals("2.2 lbf", formatter.formatAndConvertImperial(new BigDecimal("1.0"), ForceUnit.KILOGRAM_FORCE));
+    }
+
+    @Test
+    void testGetAvailableLocales() {
+        final var locales = ForceFormatter.getAvailableLocales();
+        assertArrayEquals(locales, NumberFormat.getAvailableLocales());
+    }
+
+    @Test
+    void testGetSetMaximumFractionDigits() {
+        final var formatter = new ForceFormatter();
+
+        assertEquals(formatter.getMaximumFractionDigits(), NumberFormat.getInstance().getMaximumFractionDigits());
+
+        // set new value
+        formatter.setMaximumFractionDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMaximumFractionDigits());
+    }
+
+    @Test
+    void testGetSetMaximumIntegerDigits() {
+        final var formatter = new ForceFormatter();
+
+        assertEquals(formatter.getMaximumIntegerDigits(), NumberFormat.getInstance().getMaximumIntegerDigits());
+
+        // set new value
+        formatter.setMaximumIntegerDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMaximumIntegerDigits());
+    }
+
+    @Test
+    void testGetSetMinimumFractionDigits() {
+        final var formatter = new ForceFormatter();
+
+        assertEquals(formatter.getMinimumFractionDigits(), NumberFormat.getInstance().getMinimumFractionDigits());
+
+        // set new value
+        formatter.setMinimumFractionDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMinimumFractionDigits());
+    }
+
+    @Test
+    void testGetSetMinimumIntegerDigits() {
+        final var formatter = new ForceFormatter();
+
+        assertEquals(formatter.getMinimumIntegerDigits(), NumberFormat.getInstance().getMinimumIntegerDigits());
+
+        // set new value
+        formatter.setMinimumIntegerDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMinimumIntegerDigits());
+    }
+
+    @Test
+    void testGetSetRoundingMode() {
+        final var formatter = new ForceFormatter();
+
+        assertEquals(formatter.getRoundingMode(), NumberFormat.getInstance().getRoundingMode());
+
+        // set new value
+        formatter.setRoundingMode(RoundingMode.UNNECESSARY);
+
+        // check correctness
+        assertEquals(RoundingMode.UNNECESSARY, formatter.getRoundingMode());
+    }
+
+    @Test
+    void testIsSetGroupingUsed() {
+        final var formatter = new ForceFormatter();
+
+        assertEquals(formatter.isGroupingUsed(), NumberFormat.getInstance().isGroupingUsed());
+
+        // set new value
+        formatter.setGroupingUsed(!formatter.isGroupingUsed());
+
+        // check correctness
+        assertEquals(formatter.isGroupingUsed(), !NumberFormat.getInstance().isGroupingUsed());
+    }
+
+    @Test
+    void testIsSetParseIntegerOnly() {
+        final var formatter = new ForceFormatter();
+
+        assertEquals(formatter.isParseIntegerOnly(), NumberFormat.getInstance().isParseIntegerOnly());
+
+        // set new value
+        formatter.setParseIntegerOnly(!formatter.isParseIntegerOnly());
+
+        // check correctness
+        assertEquals(formatter.isParseIntegerOnly(), !NumberFormat.getInstance().isParseIntegerOnly());
+    }
+
+    @Test
+    void testGetSetValueAndUnitFormatPattern() {
+        final var formatter = new ForceFormatter();
+
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // new value
+        formatter.setValueAndUnitFormatPattern("{0}{1}");
+
+        // check correctness
+        assertEquals("{0}{1}", formatter.getValueAndUnitFormatPattern());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> formatter.setValueAndUnitFormatPattern(null));
+    }
+
+    @Test
+    void testGetUnitSystem() {
+        var formatter = new ForceFormatter(new Locale("es", "ES"));
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem());
+
+        formatter = new ForceFormatter(new Locale("en", "US"));
+        assertEquals(UnitSystem.IMPERIAL, formatter.getUnitSystem());
+    }
+
+    @Test
+    void testIsValidUnit() {
+        final var formatter = new ForceFormatter();
+
+        assertTrue(formatter.isValidUnit("N"));
+        assertTrue(formatter.isValidUnit("N "));
+
+        assertTrue(formatter.isValidUnit("kN"));
+        assertTrue(formatter.isValidUnit("kN "));
+
+        assertTrue(formatter.isValidUnit("lbf"));
+        assertTrue(formatter.isValidUnit("lbf "));
+
+        assertTrue(formatter.isValidUnit("dyn"));
+        assertTrue(formatter.isValidUnit("dyn "));
+
+        assertTrue(formatter.isValidUnit("kgf"));
+        assertTrue(formatter.isValidUnit("kgf "));
+    }
+
+    @Test
+    void testIsValidMeasurement() {
+        final var formatter = new ForceFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 N";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 kN";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 lbf";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 dyn";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 kgf";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isValidMeasurement(text));
+
+        text = "m";
+        assertFalse(formatter.isValidMeasurement(text));
+    }
+
+    @Test
+    void testIsMetricUnit() {
+        final var formatter = new ForceFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 N";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 kN";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 dyn";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 kgf";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 lbf";
+        assertFalse(formatter.isMetricUnit(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isMetricUnit(text));
+    }
+
+    @Test
+    void testIsImperialUnit() {
+        final var formatter = new ForceFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 N";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 kN";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 dyn";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 kgf";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 lbf";
+        assertTrue(formatter.isImperialUnit(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isImperialUnit(text));
+    }
+
+    @Test
+    void testGetUnitSystemFromSource() {
+        final var formatter = new ForceFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 N";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 kN";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 dyn";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 kgf";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 lbf";
+        assertEquals(UnitSystem.IMPERIAL, formatter.getUnitSystem(text));
+
+        text = "5,5 s";
+        assertNull(formatter.getUnitSystem(text));
+    }
+
+    @Test
+    void testParse() throws ParseException, UnknownUnitException {
+        final var formatter = new ForceFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 N";
+        var f = formatter.parse(text);
+        assertEquals(5.5, f.getValue().doubleValue(), 0.0);
+        assertEquals(ForceUnit.NEWTON, f.getUnit());
+
+        text = "5,5 kN";
+        f = formatter.parse(text);
+        assertEquals(5.5, f.getValue().doubleValue(), 0.0);
+        assertEquals(ForceUnit.KILONEWTON, f.getUnit());
+
+        text = "5,5 lbf";
+        f = formatter.parse(text);
+        assertEquals(5.5, f.getValue().doubleValue(), 0.0);
+        assertEquals(ForceUnit.POUND_FORCE, f.getUnit());
+
+        text = "5,5 dyn";
+        f = formatter.parse(text);
+        assertEquals(5.5, f.getValue().doubleValue(), 0.0);
+        assertEquals(ForceUnit.DYNE, f.getUnit());
+
+        text = "5,5 kgf";
+        f = formatter.parse(text);
+        assertEquals(5.5, f.getValue().doubleValue(), 0.0);
+        assertEquals(ForceUnit.KILOGRAM_FORCE, f.getUnit());
+
+        // Force UnknownUnitException
+        assertThrows(UnknownUnitException.class, () -> formatter.parse("5,5 s"));
+
+        // Force ParseException
+        assertThrows(ParseException.class, () -> formatter.parse("m"));
+    }
+
+    @Test
+    void testFindUnit() {
+        final var formatter = new ForceFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 N";
+        assertEquals(ForceUnit.NEWTON, formatter.findUnit(text));
+
+        text = "5,5 kN";
+        assertEquals(ForceUnit.KILONEWTON, formatter.findUnit(text));
+
+        text = "5,5 lbf";
+        assertEquals(ForceUnit.POUND_FORCE, formatter.findUnit(text));
+
+        text = "5,5 dyn";
+        assertEquals(ForceUnit.DYNE, formatter.findUnit(text));
+
+        text = "5,5 kgf";
+        assertEquals(ForceUnit.KILOGRAM_FORCE, formatter.findUnit(text));
+
+        text = "5,5 s";
+        assertNull(formatter.findUnit(text));
+    }
+
+    @Test
+    void testGetUnitSymbol() {
+        final var formatter = new ForceFormatter();
+
+        assertEquals(ForceFormatter.NEWTON, formatter.getUnitSymbol(ForceUnit.NEWTON));
+        assertEquals(ForceFormatter.KILONEWTON, formatter.getUnitSymbol(ForceUnit.KILONEWTON));
+        assertEquals(ForceFormatter.POUND_FORCE, formatter.getUnitSymbol(ForceUnit.POUND_FORCE));
+        assertEquals(ForceFormatter.DYNE, formatter.getUnitSymbol(ForceUnit.DYNE));
+        assertEquals(ForceFormatter.KILOGRAM_FORCE, formatter.getUnitSymbol(ForceUnit.KILOGRAM_FORCE));
+    }
+}

--- a/src/test/java/com/irurueta/units/ForceTest.java
+++ b/src/test/java/com/irurueta/units/ForceTest.java
@@ -1,0 +1,568 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ForceTest {
+
+    private static final double ERROR = 1e-6;
+
+    @Test
+    void testConstructor() {
+        // test empty constructor
+        var f = new Force();
+
+        // check
+        assertNull(f.getValue());
+        assertNull(f.getUnit());
+
+        // test constructor with value and unit
+        f = new Force(323, ForceUnit.NEWTON);
+
+        // check
+        assertEquals(323, f.getValue());
+        assertEquals(ForceUnit.NEWTON, f.getUnit());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> new Force(null, ForceUnit.NEWTON));
+        assertThrows(IllegalArgumentException.class, () -> new Force(323, null));
+    }
+
+    @Test
+    void testEquals() {
+        final var value = new Random().nextDouble();
+        final var f1 = new Force(value, ForceUnit.NEWTON);
+        final var f2 = new Force(value, ForceUnit.NEWTON);
+        final var f3 = new Force(value + 1.0, ForceUnit.NEWTON);
+        final var f4 = new Force(value, ForceUnit.KILONEWTON);
+
+        //noinspection EqualsWithItself
+        assertEquals(f1, f1);
+        assertEquals(f1, f2);
+        assertNotEquals(f1, f3);
+        assertNotEquals(f1, f4);
+
+        assertNotEquals(null, f1);
+        assertNotEquals(f1, new Object());
+    }
+
+    @Test
+    void tetHashCode() {
+        final var value = new Random().nextDouble();
+        final var f1 = new Force(value, ForceUnit.NEWTON);
+        final var f2 = new Force(value, ForceUnit.NEWTON);
+        final var f3 = new Force(value + 1.0, ForceUnit.NEWTON);
+        final var f4 = new Force(value, ForceUnit.KILONEWTON);
+
+        assertEquals(f1.hashCode(), f1.hashCode());
+        assertEquals(f1.hashCode(), f2.hashCode());
+        assertNotEquals(f1.hashCode(), f3.hashCode());
+        assertNotEquals(f1.hashCode(), f4.hashCode());
+    }
+
+    @Test
+    void testEqualsWithTolerance() {
+        final var value = new Random().nextDouble();
+        final var f1 = new Force(value, ForceUnit.NEWTON);
+        final var f2 = new Force(value, ForceUnit.NEWTON);
+        final var f3 = new Force(value + 0.5 * ERROR, ForceUnit.NEWTON);
+        final var f4 = new Force(value, ForceUnit.KILONEWTON);
+        final var f5 = new Force(ForceConverter.convert(value, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), ForceUnit.KILONEWTON);
+
+        assertTrue(f1.equals(f1, 0.0));
+        assertTrue(f1.equals(f2, 0.0));
+        assertFalse(f1.equals(f3, 0.0));
+        assertTrue(f1.equals(f3, ERROR));
+        assertFalse(f1.equals(f4, ERROR));
+        assertTrue(f1.equals(f5, ERROR));
+
+        assertFalse(f1.equals(null, ERROR));
+    }
+
+    @Test
+    void testGetSetValue() {
+        final var f = new Force(1, ForceUnit.NEWTON);
+
+        // check
+        assertEquals(1, f.getValue());
+
+        // set new value
+        f.setValue(2.5);
+
+        // check
+        assertEquals(2.5, f.getValue());
+
+        //force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> f.setValue(null));
+    }
+
+    @Test
+    void testGetSetUnit() {
+        final var f = new Force(1, ForceUnit.NEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f.getUnit());
+
+        // set new value
+        f.setUnit(ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceUnit.KILONEWTON, f.getUnit());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> f.setUnit(null));
+    }
+
+    @Test
+    void testAdd1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Force.add(value1, ForceUnit.NEWTON, value2,
+                ForceUnit.NEWTON, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceConverter.convert(value1 + value2, ForceUnit.NEWTON,
+                        ForceUnit.KILONEWTON), result, ERROR);
+    }
+
+    @Test
+    void testAdd2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Force.add(new BigDecimal(value1), ForceUnit.NEWTON,
+                new BigDecimal(value2), ForceUnit.NEWTON, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceConverter.convert(value1 + value2, ForceUnit.NEWTON,
+                        ForceUnit.KILONEWTON), result.doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+        final var f2 = new Force(value2, ForceUnit.NEWTON);
+
+        final var result = new Force(0.0, ForceUnit.KILONEWTON);
+        Force.add(f1, f2, result);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.NEWTON, f2.getUnit());
+        assertEquals(value2, f2.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 + value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+        final var f2 = new Force(value2, ForceUnit.NEWTON);
+
+        final var result = Force.addAndReturnNew(f1, f2, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.NEWTON, f2.getUnit());
+        assertEquals(value2, f2.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 + value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+
+        final var result = f1.addAndReturnNew(value2, ForceUnit.NEWTON, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 + value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+
+        final var result = f1.addAndReturnNew(new BigDecimal(value2), ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 + value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+        final var f2 = new Force(value2, ForceUnit.NEWTON);
+
+        final var result = f1.addAndReturnNew(f2, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.NEWTON, f2.getUnit());
+        assertEquals(f2.getValue().doubleValue(), value2, 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 + value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+
+        f1.add(value2, ForceUnit.NEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1 + value2, f1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd5() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+
+        f1.add(new BigDecimal(value2), ForceUnit.NEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1 + value2, f1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd6() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+        final var f2 = new Force(value2, ForceUnit.NEWTON);
+
+        f1.add(f2);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1 + value2, f1.getValue().doubleValue(), ERROR);
+
+        assertEquals(ForceUnit.NEWTON, f2.getUnit());
+        assertEquals(value2, f2.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testAdd7() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+        final var f2 = new Force(value2, ForceUnit.NEWTON);
+
+        final var result = new Force(0.0, ForceUnit.KILONEWTON);
+        f1.add(f2, result);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.NEWTON, f2.getUnit());
+        assertEquals(value2, f2.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 + value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Force.subtract(value1, ForceUnit.NEWTON, value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceConverter.convert(value1 - value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result, ERROR);
+    }
+
+    @Test
+    void testSubtract2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Force.subtract(new BigDecimal(value1), ForceUnit.NEWTON, new BigDecimal(value2),
+                ForceUnit.NEWTON, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceConverter.convert(value1 - value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+        final var f2 = new Force(value2, ForceUnit.NEWTON);
+
+        final var result = new Force(0.0, ForceUnit.KILONEWTON);
+        Force.subtract(f1, f2, result);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.NEWTON, f2.getUnit());
+        assertEquals(value2, f2.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 - value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+        final var f2 = new Force(value2, ForceUnit.NEWTON);
+
+        final var result = Force.subtractAndReturnNew(f1, f2, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.NEWTON, f2.getUnit());
+        assertEquals(value2, f2.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 - value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+
+        final var result = f1.subtractAndReturnNew(value2, ForceUnit.NEWTON, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 - value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+
+        final var result = f1.subtractAndReturnNew(new BigDecimal(value2), ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 - value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+        final var f2 = new Force(value2, ForceUnit.NEWTON);
+
+        final var result = f1.subtractAndReturnNew(f2, ForceUnit.KILONEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.NEWTON, f2.getUnit());
+        assertEquals(value2, f2.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 - value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+
+        f1.subtract(value2, ForceUnit.NEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1 - value2, f1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract5() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+
+        f1.subtract(new BigDecimal(value2), ForceUnit.NEWTON);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1 - value2, f1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract6() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+        final var f2 = new Force(value2, ForceUnit.NEWTON);
+
+        f1.subtract(f2);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1 - value2, f1.getValue().doubleValue(), ERROR);
+
+        assertEquals(ForceUnit.NEWTON, f2.getUnit());
+        assertEquals(value2, f2.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testSubtract7() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var f1 = new Force(value1, ForceUnit.NEWTON);
+        final var f2 = new Force(value2, ForceUnit.NEWTON);
+
+        final var result = new Force(0.0, ForceUnit.KILONEWTON);
+        f1.subtract(f2, result);
+
+        // check
+        assertEquals(ForceUnit.NEWTON, f1.getUnit());
+        assertEquals(value1, f1.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.NEWTON, f2.getUnit());
+        assertEquals(value2, f2.getValue().doubleValue(), 0.0);
+
+        assertEquals(ForceUnit.KILONEWTON, result.getUnit());
+        assertEquals(ForceConverter.convert(value1 - value2, ForceUnit.NEWTON,
+                ForceUnit.KILONEWTON), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSerializeDeserialize() throws IOException, ClassNotFoundException {
+        final var value = new Random().nextDouble();
+        final var f1 = new Force(value, ForceUnit.NEWTON);
+
+        final var bytes = SerializationHelper.serialize(f1);
+        final var f2 = SerializationHelper.deserialize(bytes);
+
+        assertEquals(f1, f2);
+        assertNotSame(f1, f2);
+    }
+}

--- a/src/test/java/com/irurueta/units/ForceUnitTest.java
+++ b/src/test/java/com/irurueta/units/ForceUnitTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ForceUnitTest {
+
+    @Test
+    void testGetUnitSystem() {
+        assertEquals(UnitSystem.METRIC, ForceUnit.getUnitSystem(ForceUnit.NEWTON));
+        assertEquals(UnitSystem.METRIC, ForceUnit.getUnitSystem(ForceUnit.KILONEWTON));
+        assertEquals(UnitSystem.IMPERIAL, ForceUnit.getUnitSystem(ForceUnit.POUND_FORCE));
+        assertEquals(UnitSystem.METRIC, ForceUnit.getUnitSystem(ForceUnit.DYNE));
+        assertEquals(UnitSystem.METRIC, ForceUnit.getUnitSystem(ForceUnit.KILOGRAM_FORCE));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> ForceUnit.getUnitSystem(null));
+    }
+
+    @Test
+    void testGetMetricUnits() {
+        final var metricUnits = ForceUnit.getMetricUnits();
+        final var imperialUnits = ForceUnit.getImperialUnits();
+
+        for (final var metricUnit : metricUnits) {
+            assertTrue(ForceUnit.isMetric(metricUnit));
+            assertFalse(ForceUnit.isImperial(metricUnit));
+        }
+
+        assertEquals(metricUnits.length + imperialUnits.length, ForceUnit.values().length);
+    }
+
+    @Test
+    void testGetImperialUnits() {
+        final var metricUnits = ForceUnit.getMetricUnits();
+        final var imperialUnits = ForceUnit.getImperialUnits();
+
+        for (final var imperialUnit : imperialUnits) {
+            assertTrue(ForceUnit.isImperial(imperialUnit));
+            assertFalse(ForceUnit.isMetric(imperialUnit));
+        }
+
+        assertEquals(metricUnits.length + imperialUnits.length, ForceUnit.values().length);
+    }
+
+    @Test
+    void testIsMetric() {
+        assertTrue(ForceUnit.isMetric(ForceUnit.NEWTON));
+        assertTrue(ForceUnit.isMetric(ForceUnit.KILONEWTON));
+        assertFalse(ForceUnit.isMetric(ForceUnit.POUND_FORCE));
+        assertTrue(ForceUnit.isMetric(ForceUnit.DYNE));
+        assertTrue(ForceUnit.isMetric(ForceUnit.KILOGRAM_FORCE));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> ForceUnit.isMetric(null));
+    }
+
+    @Test
+    void testIsImperial() {
+        assertFalse(ForceUnit.isImperial(ForceUnit.NEWTON));
+        assertFalse(ForceUnit.isImperial(ForceUnit.KILONEWTON));
+        assertTrue(ForceUnit.isImperial(ForceUnit.POUND_FORCE));
+        assertFalse(ForceUnit.isImperial(ForceUnit.DYNE));
+        assertFalse(ForceUnit.isImperial(ForceUnit.KILOGRAM_FORCE));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> ForceUnit.isImperial(null));
+    }
+}

--- a/src/test/java/com/irurueta/units/PowerConverterTest.java
+++ b/src/test/java/com/irurueta/units/PowerConverterTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PowerConverterTest {
+
+    private static final double WATTS_PER_KILOWATT = 1000.0;
+    private static final double WATTS_PER_MEGAWATT = 1000000.0;
+    private static final double WATTS_PER_HORSEPOWER = 745.699872;
+
+    private static final double ERROR = 1e-6;
+
+    /**
+     * Converts provided value expressed in provided unit into watts, using locally
+     * re-declared conversion factors, independent from the ones used internally by
+     * {@link PowerConverter}.
+     *
+     * @param value value to be converted.
+     * @param unit  unit of provided value.
+     * @return value converted to watts.
+     */
+    private static double toWatts(final double value, final PowerUnit unit) {
+        return switch (unit) {
+            case KILOWATT -> value * WATTS_PER_KILOWATT;
+            case MEGAWATT -> value * WATTS_PER_MEGAWATT;
+            case HORSEPOWER -> value * WATTS_PER_HORSEPOWER;
+            default -> value;
+        };
+    }
+
+    /**
+     * Converts provided value expressed in watts into provided unit, using locally
+     * re-declared conversion factors, independent from the ones used internally by
+     * {@link PowerConverter}.
+     *
+     * @param watts value expressed in watts.
+     * @param unit  unit to convert to.
+     * @return value converted to provided unit.
+     */
+    private static double fromWatts(final double watts, final PowerUnit unit) {
+        return switch (unit) {
+            case KILOWATT -> watts / WATTS_PER_KILOWATT;
+            case MEGAWATT -> watts / WATTS_PER_MEGAWATT;
+            case HORSEPOWER -> watts / WATTS_PER_HORSEPOWER;
+            default -> watts;
+        };
+    }
+
+    @Test
+    void testWattKilowatt() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * WATTS_PER_KILOWATT, PowerConverter.kilowattToWatt(inputValue), ERROR);
+        assertEquals(inputValue / WATTS_PER_KILOWATT, PowerConverter.wattToKilowatt(inputValue), ERROR);
+    }
+
+    @Test
+    void testWattMegawatt() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * WATTS_PER_MEGAWATT, PowerConverter.megawattToWatt(inputValue), ERROR);
+        assertEquals(inputValue / WATTS_PER_MEGAWATT, PowerConverter.wattToMegawatt(inputValue), ERROR);
+    }
+
+    @Test
+    void testWattHorsepower() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * WATTS_PER_HORSEPOWER, PowerConverter.horsepowerToWatt(inputValue), ERROR);
+        assertEquals(inputValue / WATTS_PER_HORSEPOWER, PowerConverter.wattToHorsepower(inputValue), ERROR);
+    }
+
+    @Test
+    void testConvertDouble() {
+        final var inputValue = new Random().nextDouble();
+
+        for (final var inputUnit : PowerUnit.values()) {
+            for (final var outputUnit : PowerUnit.values()) {
+                final var expected = fromWatts(toWatts(inputValue, inputUnit), outputUnit);
+                assertEquals(expected, PowerConverter.convert(inputValue, inputUnit, outputUnit), ERROR);
+            }
+        }
+    }
+
+    @Test
+    void testConvertNumber() {
+        final var inputValue = BigDecimal.valueOf(new Random().nextDouble());
+
+        assertEquals(inputValue.doubleValue(),
+                PowerConverter.convert(inputValue, PowerUnit.WATT, PowerUnit.WATT).doubleValue(),
+                ERROR);
+    }
+
+    @Test
+    void testConvertPower() {
+        final var value = new Random().nextDouble();
+        final var inputPower = new Power(value, PowerUnit.WATT);
+
+        final var outputPower = new Power();
+        PowerConverter.convert(inputPower, PowerUnit.KILOWATT, outputPower);
+
+        // check
+        assertEquals(value, inputPower.getValue().doubleValue(), 0.0);
+        assertEquals(PowerUnit.WATT, inputPower.getUnit());
+
+        assertEquals(PowerUnit.KILOWATT, outputPower.getUnit());
+        assertEquals(PowerConverter.convert(value, inputPower.getUnit(), outputPower.getUnit()),
+                outputPower.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertAndUpdatePower() {
+        final var value = new Random().nextDouble();
+        final var power = new Power(value, PowerUnit.WATT);
+
+        PowerConverter.convert(power, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerUnit.KILOWATT, power.getUnit());
+        assertEquals(PowerConverter.convert(value, PowerUnit.WATT, PowerUnit.KILOWATT),
+                power.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertAndReturnNewPower() {
+        final var value = new Random().nextDouble();
+        final var inputPower = new Power(value, PowerUnit.WATT);
+
+        final var outputPower = PowerConverter.convertAndReturnNew(inputPower, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(value, inputPower.getValue().doubleValue(), 0.0);
+        assertEquals(PowerUnit.WATT, inputPower.getUnit());
+
+        assertEquals(PowerUnit.KILOWATT, outputPower.getUnit());
+        assertEquals(PowerConverter.convert(value, inputPower.getUnit(), outputPower.getUnit()),
+                outputPower.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertToOutputPowerUnit() {
+        final var value = new Random().nextDouble();
+        final var inputPower = new Power(value, PowerUnit.WATT);
+
+        final var outputPower = new Power();
+        outputPower.setUnit(PowerUnit.KILOWATT);
+        PowerConverter.convert(inputPower, outputPower);
+
+        // check
+        assertEquals(value, inputPower.getValue().doubleValue(), 0.0);
+        assertEquals(PowerUnit.WATT, inputPower.getUnit());
+
+        assertEquals(PowerUnit.KILOWATT, outputPower.getUnit());
+        assertEquals(PowerConverter.convert(value, inputPower.getUnit(),
+                outputPower.getUnit()), outputPower.getValue().doubleValue(), 0.0);
+    }
+}

--- a/src/test/java/com/irurueta/units/PowerFormatterTest.java
+++ b/src/test/java/com/irurueta/units/PowerFormatterTest.java
@@ -1,0 +1,724 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.FieldPosition;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PowerFormatterTest {
+
+    private static final double WATTS_PER_KILOWATT = 1000.0;
+    private static final double WATTS_PER_HORSEPOWER = 745.699872;
+
+    @Test
+    void testConstructor() {
+        // test empty constructor
+        var formatter = new PowerFormatter();
+
+        // check
+        assertEquals(Locale.getDefault(), formatter.getLocale());
+        assertEquals(NumberFormat.getInstance().getMaximumFractionDigits(), formatter.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance().getMaximumIntegerDigits(), formatter.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance().getMinimumFractionDigits(), formatter.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance().getMinimumIntegerDigits(), formatter.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance().getRoundingMode(), formatter.getRoundingMode());
+        assertEquals(UnitLocale.getDefault(), formatter.getUnitSystem());
+        assertEquals(NumberFormat.getInstance().isGroupingUsed(), formatter.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance().isParseIntegerOnly(), formatter.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // test constructor with locale
+        final var locale = new Locale("es", "ES");
+        formatter = new PowerFormatter(locale);
+
+        // check
+        assertEquals(locale, formatter.getLocale());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumFractionDigits(), formatter.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumIntegerDigits(), formatter.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumFractionDigits(), formatter.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumIntegerDigits(), formatter.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getRoundingMode(), formatter.getRoundingMode());
+        assertEquals(UnitLocale.getFrom(locale), formatter.getUnitSystem());
+        assertEquals(NumberFormat.getInstance(locale).isGroupingUsed(), formatter.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance(locale).isParseIntegerOnly(), formatter.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> new PowerFormatter((Locale) null));
+
+        // test copy constructor
+        formatter = new PowerFormatter(locale);
+        final var formatter2 = new PowerFormatter(formatter);
+
+        // check
+        assertEquals(locale, formatter2.getLocale());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumFractionDigits(),
+                formatter2.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumIntegerDigits(), formatter2.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumFractionDigits(),
+                formatter2.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumIntegerDigits(), formatter2.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getRoundingMode(), formatter2.getRoundingMode());
+        assertEquals(UnitLocale.getFrom(locale), formatter2.getUnitSystem());
+        assertEquals(NumberFormat.getInstance(locale).isGroupingUsed(), formatter2.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance(locale).isParseIntegerOnly(), formatter2.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter2.getValueAndUnitFormatPattern());
+
+        //noinspection DataFlowIssue
+        assertThrows(NullPointerException.class, () -> new PowerFormatter((PowerFormatter) null));
+    }
+
+    @Test
+    void testClone() throws CloneNotSupportedException {
+        final var formatter1 = new PowerFormatter();
+        final var formatter2 = (PowerFormatter) formatter1.clone();
+
+        // check
+        assertNotSame(formatter1, formatter2);
+        assertEquals(formatter1, formatter2);
+
+        // test after initializing internal number format
+        assertNotNull(formatter1.format(0.5, PowerUnit.WATT, new StringBuffer(), new FieldPosition(0)));
+        final var formatter3 = (PowerFormatter) formatter1.clone();
+
+        assertNotSame(formatter1, formatter3);
+        assertEquals(formatter1, formatter3);
+    }
+
+    @Test
+    void testEquals() {
+        final var formatter1 = new PowerFormatter(Locale.ENGLISH);
+        final var formatter2 = new PowerFormatter(Locale.ENGLISH);
+        final var formatter3 = new PowerFormatter(Locale.FRENCH);
+
+        // check
+        //noinspection EqualsWithItself
+        assertEquals(formatter1, formatter1);
+        assertEquals(formatter1, formatter2);
+        assertNotEquals(formatter1, formatter3);
+
+        assertNotEquals(formatter1, new Object());
+
+        assertNotEquals(null, formatter1);
+    }
+
+    @Test
+    void testHashCode() {
+        final var formatter1 = new PowerFormatter(Locale.ENGLISH);
+        final var formatter2 = new PowerFormatter(Locale.ENGLISH);
+        final var formatter3 = new PowerFormatter(Locale.FRENCH);
+
+        assertEquals(formatter1.hashCode(), formatter1.hashCode());
+        assertEquals(formatter1.hashCode(), formatter2.hashCode());
+        assertNotEquals(formatter1.hashCode(), formatter3.hashCode());
+    }
+
+    @Test
+    void testFormatNumber() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PowerFormatter(l);
+
+        assertEquals("5,5 W", formatter.format(new BigDecimal(value), PowerUnit.WATT));
+        assertEquals("5,5 kW", formatter.format(new BigDecimal(value), PowerUnit.KILOWATT));
+        assertEquals("5,5 MW", formatter.format(new BigDecimal(value), PowerUnit.MEGAWATT));
+        assertEquals("5,5 hp", formatter.format(new BigDecimal(value), PowerUnit.HORSEPOWER));
+    }
+
+    @Test
+    void testFormatNumberAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PowerFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 W", formatter.format(new BigDecimal(value), PowerUnit.WATT, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kW", formatter.format(new BigDecimal(value), PowerUnit.KILOWATT, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 MW", formatter.format(new BigDecimal(value), PowerUnit.MEGAWATT, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 hp", formatter.format(new BigDecimal(value), PowerUnit.HORSEPOWER, buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatDouble() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PowerFormatter(l);
+
+        assertEquals("5,5 W", formatter.format(value, PowerUnit.WATT));
+        assertEquals("5,5 kW", formatter.format(value, PowerUnit.KILOWATT));
+        assertEquals("5,5 MW", formatter.format(value, PowerUnit.MEGAWATT));
+        assertEquals("5,5 hp", formatter.format(value, PowerUnit.HORSEPOWER));
+    }
+
+    @Test
+    void testFormatDoubleAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PowerFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 W", formatter.format(value, PowerUnit.WATT, buffer, new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kW", formatter.format(value, PowerUnit.KILOWATT, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 MW", formatter.format(value, PowerUnit.MEGAWATT, buffer, new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 hp", formatter.format(value, PowerUnit.HORSEPOWER, buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatPower() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PowerFormatter(l);
+
+        assertEquals("5,5 W", formatter.format(new Power(value, PowerUnit.WATT)));
+        assertEquals("5,5 kW", formatter.format(new Power(value, PowerUnit.KILOWATT)));
+        assertEquals("5,5 MW", formatter.format(new Power(value, PowerUnit.MEGAWATT)));
+        assertEquals("5,5 hp", formatter.format(new Power(value, PowerUnit.HORSEPOWER)));
+    }
+
+    @Test
+    void testFormatPowerAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PowerFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 W", formatter.format(new Power(value, PowerUnit.WATT), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kW", formatter.format(new Power(value, PowerUnit.KILOWATT), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 MW", formatter.format(new Power(value, PowerUnit.MEGAWATT), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 hp", formatter.format(new Power(value, PowerUnit.HORSEPOWER), buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatAndConvertNumber() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.WATT),
+                formatter.formatAndConvert(new BigDecimal("5.5"), PowerUnit.WATT));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT, PowerUnit.WATT),
+                formatter.formatAndConvert(new BigDecimal("1.0"), PowerUnit.KILOWATT));
+        assertEquals(formatter.format(5.5 * WATTS_PER_HORSEPOWER, PowerUnit.WATT),
+                formatter.formatAndConvert(new BigDecimal("5.5"), PowerUnit.HORSEPOWER));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.HORSEPOWER),
+                formatter.formatAndConvert(new BigDecimal("5.5"), PowerUnit.HORSEPOWER));
+    }
+
+    @Test
+    void testFormatAndConvertDouble() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.WATT),
+                formatter.formatAndConvert(5.5, PowerUnit.WATT));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT, PowerUnit.WATT),
+                formatter.formatAndConvert(1.0, PowerUnit.KILOWATT));
+        assertEquals(formatter.format(5.5 * WATTS_PER_HORSEPOWER, PowerUnit.WATT),
+                formatter.formatAndConvert(5.5, PowerUnit.HORSEPOWER));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.HORSEPOWER),
+                formatter.formatAndConvert(5.5, PowerUnit.HORSEPOWER));
+    }
+
+    @Test
+    void testFormatAndConvertPower() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.WATT),
+                formatter.formatAndConvert(new Power(5.5, PowerUnit.WATT)));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT, PowerUnit.WATT),
+                formatter.formatAndConvert(new Power(1.0, PowerUnit.KILOWATT)));
+        assertEquals(formatter.format(5.5 * WATTS_PER_HORSEPOWER, PowerUnit.WATT),
+                formatter.formatAndConvert(new Power(5.5, PowerUnit.HORSEPOWER)));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.HORSEPOWER),
+                formatter.formatAndConvert(new Power(5.5, PowerUnit.HORSEPOWER)));
+    }
+
+    @Test
+    void testFormatAndConvertNumberAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.WATT), formatter.formatAndConvert(
+                new BigDecimal("5.5"), PowerUnit.WATT, UnitSystem.METRIC));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT, PowerUnit.WATT), formatter.formatAndConvert(
+                new BigDecimal("1.0"), PowerUnit.KILOWATT, UnitSystem.METRIC));
+
+        assertEquals(formatter.format(5.5 * WATTS_PER_HORSEPOWER, PowerUnit.WATT), formatter.formatAndConvert(
+                new BigDecimal("5.5"), PowerUnit.HORSEPOWER, UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.HORSEPOWER), formatter.formatAndConvert(
+                new BigDecimal("5.5"), PowerUnit.HORSEPOWER, UnitSystem.IMPERIAL));
+
+        assertEquals(formatter.format(5.5 / WATTS_PER_HORSEPOWER, PowerUnit.HORSEPOWER), formatter.formatAndConvert(
+                new BigDecimal("5.5"), PowerUnit.WATT, UnitSystem.IMPERIAL));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT / WATTS_PER_HORSEPOWER, PowerUnit.HORSEPOWER),
+                formatter.formatAndConvert(new BigDecimal("1.0"), PowerUnit.KILOWATT, UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertDoubleAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.WATT), formatter.formatAndConvert(
+                5.5, PowerUnit.WATT, UnitSystem.METRIC));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT, PowerUnit.WATT), formatter.formatAndConvert(
+                1.0, PowerUnit.KILOWATT, UnitSystem.METRIC));
+
+        assertEquals(formatter.format(5.5 * WATTS_PER_HORSEPOWER, PowerUnit.WATT), formatter.formatAndConvert(
+                5.5, PowerUnit.HORSEPOWER, UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.HORSEPOWER), formatter.formatAndConvert(
+                5.5, PowerUnit.HORSEPOWER, UnitSystem.IMPERIAL));
+
+        assertEquals(formatter.format(5.5 / WATTS_PER_HORSEPOWER, PowerUnit.HORSEPOWER), formatter.formatAndConvert(
+                5.5, PowerUnit.WATT, UnitSystem.IMPERIAL));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT / WATTS_PER_HORSEPOWER, PowerUnit.HORSEPOWER),
+                formatter.formatAndConvert(1.0, PowerUnit.KILOWATT, UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertPowerAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.WATT), formatter.formatAndConvert(
+                new Power(5.5, PowerUnit.WATT), UnitSystem.METRIC));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT, PowerUnit.WATT), formatter.formatAndConvert(
+                new Power(1.0, PowerUnit.KILOWATT), UnitSystem.METRIC));
+
+        assertEquals(formatter.format(5.5 * WATTS_PER_HORSEPOWER, PowerUnit.WATT), formatter.formatAndConvert(
+                new Power(5.5, PowerUnit.HORSEPOWER), UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.HORSEPOWER), formatter.formatAndConvert(
+                new Power(5.5, PowerUnit.HORSEPOWER), UnitSystem.IMPERIAL));
+
+        assertEquals(formatter.format(5.5 / WATTS_PER_HORSEPOWER, PowerUnit.HORSEPOWER), formatter.formatAndConvert(
+                new Power(5.5, PowerUnit.WATT), UnitSystem.IMPERIAL));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT / WATTS_PER_HORSEPOWER, PowerUnit.HORSEPOWER),
+                formatter.formatAndConvert(new Power(1.0, PowerUnit.KILOWATT), UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertMetric() {
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.WATT),
+                formatter.formatAndConvertMetric(new BigDecimal("5.5"), PowerUnit.WATT));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT, PowerUnit.WATT),
+                formatter.formatAndConvertMetric(new BigDecimal("1.0"), PowerUnit.KILOWATT));
+        assertEquals(formatter.format(5.5 * WATTS_PER_HORSEPOWER, PowerUnit.WATT),
+                formatter.formatAndConvertMetric(new BigDecimal("5.5"), PowerUnit.HORSEPOWER));
+    }
+
+    @Test
+    void testFormatAndConvertImperial() {
+        final var l = new Locale("en", "US");
+
+        final var formatter = new PowerFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PowerUnit.HORSEPOWER),
+                formatter.formatAndConvertImperial(new BigDecimal("5.5"), PowerUnit.HORSEPOWER));
+
+        assertEquals(formatter.format(5.5 / WATTS_PER_HORSEPOWER, PowerUnit.HORSEPOWER),
+                formatter.formatAndConvertImperial(new BigDecimal("5.5"), PowerUnit.WATT));
+        assertEquals(formatter.format(1.0 * WATTS_PER_KILOWATT / WATTS_PER_HORSEPOWER, PowerUnit.HORSEPOWER),
+                formatter.formatAndConvertImperial(new BigDecimal("1.0"), PowerUnit.KILOWATT));
+    }
+
+    @Test
+    void testGetAvailableLocales() {
+        final var locales = PowerFormatter.getAvailableLocales();
+        assertArrayEquals(locales, NumberFormat.getAvailableLocales());
+    }
+
+    @Test
+    void testGetSetMaximumFractionDigits() {
+        final var formatter = new PowerFormatter();
+
+        assertEquals(formatter.getMaximumFractionDigits(), NumberFormat.getInstance().getMaximumFractionDigits());
+
+        // set new value
+        formatter.setMaximumFractionDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMaximumFractionDigits());
+    }
+
+    @Test
+    void testGetSetMaximumIntegerDigits() {
+        final var formatter = new PowerFormatter();
+
+        assertEquals(formatter.getMaximumIntegerDigits(), NumberFormat.getInstance().getMaximumIntegerDigits());
+
+        // set new value
+        formatter.setMaximumIntegerDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMaximumIntegerDigits());
+    }
+
+    @Test
+    void testGetSetMinimumFractionDigits() {
+        final var formatter = new PowerFormatter();
+
+        assertEquals(formatter.getMinimumFractionDigits(), NumberFormat.getInstance().getMinimumFractionDigits());
+
+        // set new value
+        formatter.setMinimumFractionDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMinimumFractionDigits());
+    }
+
+    @Test
+    void testGetSetMinimumIntegerDigits() {
+        final var formatter = new PowerFormatter();
+
+        assertEquals(formatter.getMinimumIntegerDigits(), NumberFormat.getInstance().getMinimumIntegerDigits());
+
+        // set new value
+        formatter.setMinimumIntegerDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMinimumIntegerDigits());
+    }
+
+    @Test
+    void testGetSetRoundingMode() {
+        final var formatter = new PowerFormatter();
+
+        assertEquals(formatter.getRoundingMode(), NumberFormat.getInstance().getRoundingMode());
+
+        // set new value
+        formatter.setRoundingMode(RoundingMode.UNNECESSARY);
+
+        // check correctness
+        assertEquals(RoundingMode.UNNECESSARY, formatter.getRoundingMode());
+    }
+
+    @Test
+    void testIsSetGroupingUsed() {
+        final var formatter = new PowerFormatter();
+
+        assertEquals(formatter.isGroupingUsed(), NumberFormat.getInstance().isGroupingUsed());
+
+        // set new value
+        formatter.setGroupingUsed(!formatter.isGroupingUsed());
+
+        // check correctness
+        assertEquals(formatter.isGroupingUsed(), !NumberFormat.getInstance().isGroupingUsed());
+    }
+
+    @Test
+    void testIsSetParseIntegerOnly() {
+        final var formatter = new PowerFormatter();
+
+        assertEquals(formatter.isParseIntegerOnly(), NumberFormat.getInstance().isParseIntegerOnly());
+
+        // set new value
+        formatter.setParseIntegerOnly(!formatter.isParseIntegerOnly());
+
+        // check correctness
+        assertEquals(formatter.isParseIntegerOnly(), !NumberFormat.getInstance().isParseIntegerOnly());
+    }
+
+    @Test
+    void testGetSetValueAndUnitFormatPattern() {
+        final var formatter = new PowerFormatter();
+
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // new value
+        formatter.setValueAndUnitFormatPattern("{0}{1}");
+
+        // check correctness
+        assertEquals("{0}{1}", formatter.getValueAndUnitFormatPattern());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> formatter.setValueAndUnitFormatPattern(null));
+    }
+
+    @Test
+    void testGetUnitSystem() {
+        var formatter = new PowerFormatter(new Locale("es", "ES"));
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem());
+
+        formatter = new PowerFormatter(new Locale("en", "US"));
+        assertEquals(UnitSystem.IMPERIAL, formatter.getUnitSystem());
+    }
+
+    @Test
+    void testIsValidUnit() {
+        final var formatter = new PowerFormatter();
+
+        assertTrue(formatter.isValidUnit("W"));
+        assertTrue(formatter.isValidUnit("W "));
+
+        assertTrue(formatter.isValidUnit("kW"));
+        assertTrue(formatter.isValidUnit("kW "));
+
+        assertTrue(formatter.isValidUnit("MW"));
+        assertTrue(formatter.isValidUnit("MW "));
+
+        assertTrue(formatter.isValidUnit("hp"));
+        assertTrue(formatter.isValidUnit("hp "));
+    }
+
+    @Test
+    void testIsValidMeasurement() {
+        final var formatter = new PowerFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 W";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 kW";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 MW";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 hp";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isValidMeasurement(text));
+
+        text = "m";
+        assertFalse(formatter.isValidMeasurement(text));
+    }
+
+    @Test
+    void testIsMetricUnit() {
+        final var formatter = new PowerFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 W";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 kW";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 MW";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 hp";
+        assertFalse(formatter.isMetricUnit(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isMetricUnit(text));
+    }
+
+    @Test
+    void testIsImperialUnit() {
+        final var formatter = new PowerFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 W";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 kW";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 MW";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 hp";
+        assertTrue(formatter.isImperialUnit(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isImperialUnit(text));
+    }
+
+    @Test
+    void testGetUnitSystemFromSource() {
+        final var formatter = new PowerFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 W";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 kW";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 MW";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 hp";
+        assertEquals(UnitSystem.IMPERIAL, formatter.getUnitSystem(text));
+
+        text = "5,5 s";
+        assertNull(formatter.getUnitSystem(text));
+    }
+
+    @Test
+    void testParse() throws ParseException, UnknownUnitException {
+        final var formatter = new PowerFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 W";
+        var p = formatter.parse(text);
+        assertEquals(5.5, p.getValue().doubleValue(), 0.0);
+        assertEquals(PowerUnit.WATT, p.getUnit());
+
+        text = "5,5 kW";
+        p = formatter.parse(text);
+        assertEquals(5.5, p.getValue().doubleValue(), 0.0);
+        assertEquals(PowerUnit.KILOWATT, p.getUnit());
+
+        text = "5,5 MW";
+        p = formatter.parse(text);
+        assertEquals(5.5, p.getValue().doubleValue(), 0.0);
+        assertEquals(PowerUnit.MEGAWATT, p.getUnit());
+
+        text = "5,5 hp";
+        p = formatter.parse(text);
+        assertEquals(5.5, p.getValue().doubleValue(), 0.0);
+        assertEquals(PowerUnit.HORSEPOWER, p.getUnit());
+
+        // Force UnknownUnitException
+        assertThrows(UnknownUnitException.class, () -> formatter.parse("5,5 s"));
+
+        // Force ParseException
+        assertThrows(ParseException.class, () -> formatter.parse("m"));
+    }
+
+    @Test
+    void testFindUnit() {
+        final var formatter = new PowerFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 W";
+        assertEquals(PowerUnit.WATT, formatter.findUnit(text));
+
+        text = "5,5 kW";
+        assertEquals(PowerUnit.KILOWATT, formatter.findUnit(text));
+
+        text = "5,5 MW";
+        assertEquals(PowerUnit.MEGAWATT, formatter.findUnit(text));
+
+        text = "5,5 hp";
+        assertEquals(PowerUnit.HORSEPOWER, formatter.findUnit(text));
+
+        text = "5,5 s";
+        assertNull(formatter.findUnit(text));
+    }
+
+    @Test
+    void testGetUnitSymbol() {
+        final var formatter = new PowerFormatter();
+
+        assertEquals(PowerFormatter.WATT, formatter.getUnitSymbol(PowerUnit.WATT));
+        assertEquals(PowerFormatter.KILOWATT, formatter.getUnitSymbol(PowerUnit.KILOWATT));
+        assertEquals(PowerFormatter.MEGAWATT, formatter.getUnitSymbol(PowerUnit.MEGAWATT));
+        assertEquals(PowerFormatter.HORSEPOWER, formatter.getUnitSymbol(PowerUnit.HORSEPOWER));
+    }
+}

--- a/src/test/java/com/irurueta/units/PowerTest.java
+++ b/src/test/java/com/irurueta/units/PowerTest.java
@@ -1,0 +1,568 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PowerTest {
+
+    private static final double ERROR = 1e-6;
+
+    @Test
+    void testConstructor() {
+        // test empty constructor
+        var p = new Power();
+
+        // check
+        assertNull(p.getValue());
+        assertNull(p.getUnit());
+
+        // test constructor with value and unit
+        p = new Power(323, PowerUnit.WATT);
+
+        // check
+        assertEquals(323, p.getValue());
+        assertEquals(PowerUnit.WATT, p.getUnit());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> new Power(null, PowerUnit.WATT));
+        assertThrows(IllegalArgumentException.class, () -> new Power(323, null));
+    }
+
+    @Test
+    void testEquals() {
+        final var value = new Random().nextDouble();
+        final var p1 = new Power(value, PowerUnit.WATT);
+        final var p2 = new Power(value, PowerUnit.WATT);
+        final var p3 = new Power(value + 1.0, PowerUnit.WATT);
+        final var p4 = new Power(value, PowerUnit.KILOWATT);
+
+        //noinspection EqualsWithItself
+        assertEquals(p1, p1);
+        assertEquals(p1, p2);
+        assertNotEquals(p1, p3);
+        assertNotEquals(p1, p4);
+
+        assertNotEquals(null, p1);
+        assertNotEquals(p1, new Object());
+    }
+
+    @Test
+    void tetHashCode() {
+        final var value = new Random().nextDouble();
+        final var p1 = new Power(value, PowerUnit.WATT);
+        final var p2 = new Power(value, PowerUnit.WATT);
+        final var p3 = new Power(value + 1.0, PowerUnit.WATT);
+        final var p4 = new Power(value, PowerUnit.KILOWATT);
+
+        assertEquals(p1.hashCode(), p1.hashCode());
+        assertEquals(p1.hashCode(), p2.hashCode());
+        assertNotEquals(p1.hashCode(), p3.hashCode());
+        assertNotEquals(p1.hashCode(), p4.hashCode());
+    }
+
+    @Test
+    void testEqualsWithTolerance() {
+        final var value = new Random().nextDouble();
+        final var p1 = new Power(value, PowerUnit.WATT);
+        final var p2 = new Power(value, PowerUnit.WATT);
+        final var p3 = new Power(value + 0.5 * ERROR, PowerUnit.WATT);
+        final var p4 = new Power(value, PowerUnit.KILOWATT);
+        final var p5 = new Power(PowerConverter.convert(value, PowerUnit.WATT,
+                PowerUnit.KILOWATT), PowerUnit.KILOWATT);
+
+        assertTrue(p1.equals(p1, 0.0));
+        assertTrue(p1.equals(p2, 0.0));
+        assertFalse(p1.equals(p3, 0.0));
+        assertTrue(p1.equals(p3, ERROR));
+        assertFalse(p1.equals(p4, ERROR));
+        assertTrue(p1.equals(p5, ERROR));
+
+        assertFalse(p1.equals(null, ERROR));
+    }
+
+    @Test
+    void testGetSetValue() {
+        final var p = new Power(1, PowerUnit.WATT);
+
+        // check
+        assertEquals(1, p.getValue());
+
+        // set new value
+        p.setValue(2.5);
+
+        // check
+        assertEquals(2.5, p.getValue());
+
+        //force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> p.setValue(null));
+    }
+
+    @Test
+    void testGetSetUnit() {
+        final var p = new Power(1, PowerUnit.WATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p.getUnit());
+
+        // set new value
+        p.setUnit(PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerUnit.KILOWATT, p.getUnit());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> p.setUnit(null));
+    }
+
+    @Test
+    void testAdd1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Power.add(value1, PowerUnit.WATT, value2,
+                PowerUnit.WATT, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerConverter.convert(value1 + value2, PowerUnit.WATT,
+                        PowerUnit.KILOWATT), result, ERROR);
+    }
+
+    @Test
+    void testAdd2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Power.add(new BigDecimal(value1), PowerUnit.WATT,
+                new BigDecimal(value2), PowerUnit.WATT, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerConverter.convert(value1 + value2, PowerUnit.WATT,
+                        PowerUnit.KILOWATT), result.doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+        final var p2 = new Power(value2, PowerUnit.WATT);
+
+        final var result = new Power(0.0, PowerUnit.KILOWATT);
+        Power.add(p1, p2, result);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.WATT, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 + value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+        final var p2 = new Power(value2, PowerUnit.WATT);
+
+        final var result = Power.addAndReturnNew(p1, p2, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.WATT, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 + value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+
+        final var result = p1.addAndReturnNew(value2, PowerUnit.WATT, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 + value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+
+        final var result = p1.addAndReturnNew(new BigDecimal(value2), PowerUnit.WATT,
+                PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 + value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+        final var p2 = new Power(value2, PowerUnit.WATT);
+
+        final var result = p1.addAndReturnNew(p2, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.WATT, p2.getUnit());
+        assertEquals(p2.getValue().doubleValue(), value2, 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 + value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+
+        p1.add(value2, PowerUnit.WATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1 + value2, p1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd5() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+
+        p1.add(new BigDecimal(value2), PowerUnit.WATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1 + value2, p1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd6() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+        final var p2 = new Power(value2, PowerUnit.WATT);
+
+        p1.add(p2);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1 + value2, p1.getValue().doubleValue(), ERROR);
+
+        assertEquals(PowerUnit.WATT, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testAdd7() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+        final var p2 = new Power(value2, PowerUnit.WATT);
+
+        final var result = new Power(0.0, PowerUnit.KILOWATT);
+        p1.add(p2, result);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.WATT, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 + value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Power.subtract(value1, PowerUnit.WATT, value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerConverter.convert(value1 - value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result, ERROR);
+    }
+
+    @Test
+    void testSubtract2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Power.subtract(new BigDecimal(value1), PowerUnit.WATT, new BigDecimal(value2),
+                PowerUnit.WATT, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerConverter.convert(value1 - value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+        final var p2 = new Power(value2, PowerUnit.WATT);
+
+        final var result = new Power(0.0, PowerUnit.KILOWATT);
+        Power.subtract(p1, p2, result);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.WATT, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 - value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+        final var p2 = new Power(value2, PowerUnit.WATT);
+
+        final var result = Power.subtractAndReturnNew(p1, p2, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.WATT, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 - value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+
+        final var result = p1.subtractAndReturnNew(value2, PowerUnit.WATT, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 - value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+
+        final var result = p1.subtractAndReturnNew(new BigDecimal(value2), PowerUnit.WATT,
+                PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 - value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+        final var p2 = new Power(value2, PowerUnit.WATT);
+
+        final var result = p1.subtractAndReturnNew(p2, PowerUnit.KILOWATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.WATT, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 - value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+
+        p1.subtract(value2, PowerUnit.WATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1 - value2, p1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract5() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+
+        p1.subtract(new BigDecimal(value2), PowerUnit.WATT);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1 - value2, p1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract6() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+        final var p2 = new Power(value2, PowerUnit.WATT);
+
+        p1.subtract(p2);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1 - value2, p1.getValue().doubleValue(), ERROR);
+
+        assertEquals(PowerUnit.WATT, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testSubtract7() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Power(value1, PowerUnit.WATT);
+        final var p2 = new Power(value2, PowerUnit.WATT);
+
+        final var result = new Power(0.0, PowerUnit.KILOWATT);
+        p1.subtract(p2, result);
+
+        // check
+        assertEquals(PowerUnit.WATT, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.WATT, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PowerUnit.KILOWATT, result.getUnit());
+        assertEquals(PowerConverter.convert(value1 - value2, PowerUnit.WATT,
+                PowerUnit.KILOWATT), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSerializeDeserialize() throws IOException, ClassNotFoundException {
+        final var value = new Random().nextDouble();
+        final var p1 = new Power(value, PowerUnit.WATT);
+
+        final var bytes = SerializationHelper.serialize(p1);
+        final var p2 = SerializationHelper.deserialize(bytes);
+
+        assertEquals(p1, p2);
+        assertNotSame(p1, p2);
+    }
+}

--- a/src/test/java/com/irurueta/units/PowerUnitTest.java
+++ b/src/test/java/com/irurueta/units/PowerUnitTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PowerUnitTest {
+
+    @Test
+    void testGetUnitSystem() {
+        assertEquals(UnitSystem.METRIC, PowerUnit.getUnitSystem(PowerUnit.WATT));
+        assertEquals(UnitSystem.METRIC, PowerUnit.getUnitSystem(PowerUnit.KILOWATT));
+        assertEquals(UnitSystem.METRIC, PowerUnit.getUnitSystem(PowerUnit.MEGAWATT));
+        assertEquals(UnitSystem.IMPERIAL, PowerUnit.getUnitSystem(PowerUnit.HORSEPOWER));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> PowerUnit.getUnitSystem(null));
+    }
+
+    @Test
+    void testGetMetricUnits() {
+        final var metricUnits = PowerUnit.getMetricUnits();
+        final var imperialUnits = PowerUnit.getImperialUnits();
+
+        for (final var metricUnit : metricUnits) {
+            assertTrue(PowerUnit.isMetric(metricUnit));
+            assertFalse(PowerUnit.isImperial(metricUnit));
+        }
+
+        assertEquals(metricUnits.length + imperialUnits.length, PowerUnit.values().length);
+    }
+
+    @Test
+    void testGetImperialUnits() {
+        final var metricUnits = PowerUnit.getMetricUnits();
+        final var imperialUnits = PowerUnit.getImperialUnits();
+
+        for (final var imperialUnit : imperialUnits) {
+            assertTrue(PowerUnit.isImperial(imperialUnit));
+            assertFalse(PowerUnit.isMetric(imperialUnit));
+        }
+
+        assertEquals(metricUnits.length + imperialUnits.length, PowerUnit.values().length);
+    }
+
+    @Test
+    void testIsMetric() {
+        assertTrue(PowerUnit.isMetric(PowerUnit.WATT));
+        assertTrue(PowerUnit.isMetric(PowerUnit.KILOWATT));
+        assertTrue(PowerUnit.isMetric(PowerUnit.MEGAWATT));
+        assertFalse(PowerUnit.isMetric(PowerUnit.HORSEPOWER));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> PowerUnit.isMetric(null));
+    }
+
+    @Test
+    void testIsImperial() {
+        assertFalse(PowerUnit.isImperial(PowerUnit.WATT));
+        assertFalse(PowerUnit.isImperial(PowerUnit.KILOWATT));
+        assertFalse(PowerUnit.isImperial(PowerUnit.MEGAWATT));
+        assertTrue(PowerUnit.isImperial(PowerUnit.HORSEPOWER));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> PowerUnit.isImperial(null));
+    }
+}

--- a/src/test/java/com/irurueta/units/PressureConverterTest.java
+++ b/src/test/java/com/irurueta/units/PressureConverterTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PressureConverterTest {
+
+    private static final double PASCALS_PER_KILOPASCAL = 1000.0;
+    private static final double PASCALS_PER_BAR = 100000.0;
+    private static final double PASCALS_PER_ATMOSPHERE = 101325.0;
+    private static final double PASCALS_PER_PSI = 6894.757293168;
+
+    private static final double ERROR = 1e-6;
+
+    /**
+     * Converts provided value expressed in provided unit into pascals, using locally
+     * re-declared conversion factors, independent from the ones used internally by
+     * {@link PressureConverter}.
+     *
+     * @param value value to be converted.
+     * @param unit  unit of provided value.
+     * @return value converted to pascals.
+     */
+    private static double toPascals(final double value, final PressureUnit unit) {
+        return switch (unit) {
+            case KILOPASCAL -> value * PASCALS_PER_KILOPASCAL;
+            case BAR -> value * PASCALS_PER_BAR;
+            case ATMOSPHERE -> value * PASCALS_PER_ATMOSPHERE;
+            case PSI -> value * PASCALS_PER_PSI;
+            default -> value;
+        };
+    }
+
+    /**
+     * Converts provided value expressed in pascals into provided unit, using locally
+     * re-declared conversion factors, independent from the ones used internally by
+     * {@link PressureConverter}.
+     *
+     * @param pascals value expressed in pascals.
+     * @param unit    unit to convert to.
+     * @return value converted to provided unit.
+     */
+    private static double fromPascals(final double pascals, final PressureUnit unit) {
+        return switch (unit) {
+            case KILOPASCAL -> pascals / PASCALS_PER_KILOPASCAL;
+            case BAR -> pascals / PASCALS_PER_BAR;
+            case ATMOSPHERE -> pascals / PASCALS_PER_ATMOSPHERE;
+            case PSI -> pascals / PASCALS_PER_PSI;
+            default -> pascals;
+        };
+    }
+
+    @Test
+    void testPascalKilopascal() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * PASCALS_PER_KILOPASCAL, PressureConverter.kilopascalToPascal(inputValue), ERROR);
+        assertEquals(inputValue / PASCALS_PER_KILOPASCAL, PressureConverter.pascalToKilopascal(inputValue), ERROR);
+    }
+
+    @Test
+    void testPascalBar() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * PASCALS_PER_BAR, PressureConverter.barToPascal(inputValue), ERROR);
+        assertEquals(inputValue / PASCALS_PER_BAR, PressureConverter.pascalToBar(inputValue), ERROR);
+    }
+
+    @Test
+    void testPascalAtmosphere() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * PASCALS_PER_ATMOSPHERE, PressureConverter.atmosphereToPascal(inputValue),
+                ERROR);
+        assertEquals(inputValue / PASCALS_PER_ATMOSPHERE, PressureConverter.pascalToAtmosphere(inputValue),
+                ERROR);
+    }
+
+    @Test
+    void testPascalPsi() {
+        final var inputValue = new Random().nextDouble();
+
+        assertEquals(inputValue * PASCALS_PER_PSI, PressureConverter.psiToPascal(inputValue), ERROR);
+        assertEquals(inputValue / PASCALS_PER_PSI, PressureConverter.pascalToPsi(inputValue), ERROR);
+    }
+
+    @Test
+    void testConvertDouble() {
+        final var inputValue = new Random().nextDouble();
+
+        for (final var inputUnit : PressureUnit.values()) {
+            for (final var outputUnit : PressureUnit.values()) {
+                final var expected = fromPascals(toPascals(inputValue, inputUnit), outputUnit);
+                assertEquals(expected, PressureConverter.convert(inputValue, inputUnit, outputUnit), ERROR);
+            }
+        }
+    }
+
+    @Test
+    void testConvertNumber() {
+        final var inputValue = BigDecimal.valueOf(new Random().nextDouble());
+
+        assertEquals(inputValue.doubleValue(),
+                PressureConverter.convert(inputValue, PressureUnit.PASCAL, PressureUnit.PASCAL).doubleValue(),
+                ERROR);
+    }
+
+    @Test
+    void testConvertPressure() {
+        final var value = new Random().nextDouble();
+        final var inputPressure = new Pressure(value, PressureUnit.PASCAL);
+
+        final var outputPressure = new Pressure();
+        PressureConverter.convert(inputPressure, PressureUnit.KILOPASCAL, outputPressure);
+
+        // check
+        assertEquals(value, inputPressure.getValue().doubleValue(), 0.0);
+        assertEquals(PressureUnit.PASCAL, inputPressure.getUnit());
+
+        assertEquals(PressureUnit.KILOPASCAL, outputPressure.getUnit());
+        assertEquals(PressureConverter.convert(value, inputPressure.getUnit(), outputPressure.getUnit()),
+                outputPressure.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertAndUpdatePressure() {
+        final var value = new Random().nextDouble();
+        final var pressure = new Pressure(value, PressureUnit.PASCAL);
+
+        PressureConverter.convert(pressure, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureUnit.KILOPASCAL, pressure.getUnit());
+        assertEquals(PressureConverter.convert(value, PressureUnit.PASCAL, PressureUnit.KILOPASCAL),
+                pressure.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertAndReturnNewPressure() {
+        final var value = new Random().nextDouble();
+        final var inputPressure = new Pressure(value, PressureUnit.PASCAL);
+
+        final var outputPressure = PressureConverter.convertAndReturnNew(inputPressure, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(value, inputPressure.getValue().doubleValue(), 0.0);
+        assertEquals(PressureUnit.PASCAL, inputPressure.getUnit());
+
+        assertEquals(PressureUnit.KILOPASCAL, outputPressure.getUnit());
+        assertEquals(PressureConverter.convert(value, inputPressure.getUnit(), outputPressure.getUnit()),
+                outputPressure.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testConvertToOutputPressureUnit() {
+        final var value = new Random().nextDouble();
+        final var inputPressure = new Pressure(value, PressureUnit.PASCAL);
+
+        final var outputPressure = new Pressure();
+        outputPressure.setUnit(PressureUnit.KILOPASCAL);
+        PressureConverter.convert(inputPressure, outputPressure);
+
+        // check
+        assertEquals(value, inputPressure.getValue().doubleValue(), 0.0);
+        assertEquals(PressureUnit.PASCAL, inputPressure.getUnit());
+
+        assertEquals(PressureUnit.KILOPASCAL, outputPressure.getUnit());
+        assertEquals(PressureConverter.convert(value, inputPressure.getUnit(),
+                outputPressure.getUnit()), outputPressure.getValue().doubleValue(), 0.0);
+    }
+}

--- a/src/test/java/com/irurueta/units/PressureFormatterTest.java
+++ b/src/test/java/com/irurueta/units/PressureFormatterTest.java
@@ -1,0 +1,763 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.FieldPosition;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PressureFormatterTest {
+
+    private static final double PASCALS_PER_KILOPASCAL = 1000.0;
+    private static final double PASCALS_PER_PSI = 6894.757293168;
+
+    @Test
+    void testConstructor() {
+        // test empty constructor
+        var formatter = new PressureFormatter();
+
+        // check
+        assertEquals(Locale.getDefault(), formatter.getLocale());
+        assertEquals(NumberFormat.getInstance().getMaximumFractionDigits(), formatter.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance().getMaximumIntegerDigits(), formatter.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance().getMinimumFractionDigits(), formatter.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance().getMinimumIntegerDigits(), formatter.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance().getRoundingMode(), formatter.getRoundingMode());
+        assertEquals(UnitLocale.getDefault(), formatter.getUnitSystem());
+        assertEquals(NumberFormat.getInstance().isGroupingUsed(), formatter.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance().isParseIntegerOnly(), formatter.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // test constructor with locale
+        final var locale = new Locale("es", "ES");
+        formatter = new PressureFormatter(locale);
+
+        // check
+        assertEquals(locale, formatter.getLocale());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumFractionDigits(), formatter.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumIntegerDigits(), formatter.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumFractionDigits(), formatter.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumIntegerDigits(), formatter.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getRoundingMode(), formatter.getRoundingMode());
+        assertEquals(UnitLocale.getFrom(locale), formatter.getUnitSystem());
+        assertEquals(NumberFormat.getInstance(locale).isGroupingUsed(), formatter.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance(locale).isParseIntegerOnly(), formatter.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> new PressureFormatter((Locale) null));
+
+        // test copy constructor
+        formatter = new PressureFormatter(locale);
+        final var formatter2 = new PressureFormatter(formatter);
+
+        // check
+        assertEquals(locale, formatter2.getLocale());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumFractionDigits(),
+                formatter2.getMaximumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMaximumIntegerDigits(), formatter2.getMaximumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumFractionDigits(),
+                formatter2.getMinimumFractionDigits());
+        assertEquals(NumberFormat.getInstance(locale).getMinimumIntegerDigits(), formatter2.getMinimumIntegerDigits());
+        assertEquals(NumberFormat.getInstance(locale).getRoundingMode(), formatter2.getRoundingMode());
+        assertEquals(UnitLocale.getFrom(locale), formatter2.getUnitSystem());
+        assertEquals(NumberFormat.getInstance(locale).isGroupingUsed(), formatter2.isGroupingUsed());
+        assertEquals(NumberFormat.getInstance(locale).isParseIntegerOnly(), formatter2.isParseIntegerOnly());
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter2.getValueAndUnitFormatPattern());
+
+        //noinspection DataFlowIssue
+        assertThrows(NullPointerException.class, () -> new PressureFormatter((PressureFormatter) null));
+    }
+
+    @Test
+    void testClone() throws CloneNotSupportedException {
+        final var formatter1 = new PressureFormatter();
+        final var formatter2 = (PressureFormatter) formatter1.clone();
+
+        // check
+        assertNotSame(formatter1, formatter2);
+        assertEquals(formatter1, formatter2);
+
+        // test after initializing internal number format
+        assertNotNull(formatter1.format(0.5, PressureUnit.PASCAL, new StringBuffer(), new FieldPosition(0)));
+        final var formatter3 = (PressureFormatter) formatter1.clone();
+
+        assertNotSame(formatter1, formatter3);
+        assertEquals(formatter1, formatter3);
+    }
+
+    @Test
+    void testEquals() {
+        final var formatter1 = new PressureFormatter(Locale.ENGLISH);
+        final var formatter2 = new PressureFormatter(Locale.ENGLISH);
+        final var formatter3 = new PressureFormatter(Locale.FRENCH);
+
+        // check
+        //noinspection EqualsWithItself
+        assertEquals(formatter1, formatter1);
+        assertEquals(formatter1, formatter2);
+        assertNotEquals(formatter1, formatter3);
+
+        assertNotEquals(formatter1, new Object());
+
+        assertNotEquals(null, formatter1);
+    }
+
+    @Test
+    void testHashCode() {
+        final var formatter1 = new PressureFormatter(Locale.ENGLISH);
+        final var formatter2 = new PressureFormatter(Locale.ENGLISH);
+        final var formatter3 = new PressureFormatter(Locale.FRENCH);
+
+        assertEquals(formatter1.hashCode(), formatter1.hashCode());
+        assertEquals(formatter1.hashCode(), formatter2.hashCode());
+        assertNotEquals(formatter1.hashCode(), formatter3.hashCode());
+    }
+
+    @Test
+    void testFormatNumber() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PressureFormatter(l);
+
+        assertEquals("5,5 Pa", formatter.format(new BigDecimal(value), PressureUnit.PASCAL));
+        assertEquals("5,5 kPa", formatter.format(new BigDecimal(value), PressureUnit.KILOPASCAL));
+        assertEquals("5,5 bar", formatter.format(new BigDecimal(value), PressureUnit.BAR));
+        assertEquals("5,5 atm", formatter.format(new BigDecimal(value), PressureUnit.ATMOSPHERE));
+        assertEquals("5,5 psi", formatter.format(new BigDecimal(value), PressureUnit.PSI));
+    }
+
+    @Test
+    void testFormatNumberAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PressureFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 Pa", formatter.format(new BigDecimal(value), PressureUnit.PASCAL, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kPa", formatter.format(new BigDecimal(value), PressureUnit.KILOPASCAL, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 bar", formatter.format(new BigDecimal(value), PressureUnit.BAR, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 atm", formatter.format(new BigDecimal(value), PressureUnit.ATMOSPHERE, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 psi", formatter.format(new BigDecimal(value), PressureUnit.PSI, buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatDouble() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PressureFormatter(l);
+
+        assertEquals("5,5 Pa", formatter.format(value, PressureUnit.PASCAL));
+        assertEquals("5,5 kPa", formatter.format(value, PressureUnit.KILOPASCAL));
+        assertEquals("5,5 bar", formatter.format(value, PressureUnit.BAR));
+        assertEquals("5,5 atm", formatter.format(value, PressureUnit.ATMOSPHERE));
+        assertEquals("5,5 psi", formatter.format(value, PressureUnit.PSI));
+    }
+
+    @Test
+    void testFormatDoubleAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PressureFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 Pa", formatter.format(value, PressureUnit.PASCAL, buffer, new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kPa", formatter.format(value, PressureUnit.KILOPASCAL, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 bar", formatter.format(value, PressureUnit.BAR, buffer, new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 atm", formatter.format(value, PressureUnit.ATMOSPHERE, buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 psi", formatter.format(value, PressureUnit.PSI, buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatPressure() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PressureFormatter(l);
+
+        assertEquals("5,5 Pa", formatter.format(new Pressure(value, PressureUnit.PASCAL)));
+        assertEquals("5,5 kPa", formatter.format(new Pressure(value, PressureUnit.KILOPASCAL)));
+        assertEquals("5,5 bar", formatter.format(new Pressure(value, PressureUnit.BAR)));
+        assertEquals("5,5 atm", formatter.format(new Pressure(value, PressureUnit.ATMOSPHERE)));
+        assertEquals("5,5 psi", formatter.format(new Pressure(value, PressureUnit.PSI)));
+    }
+
+    @Test
+    void testFormatPressureAndStringBuffer() {
+        final var value = 5.50;
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PressureFormatter(l);
+
+        var buffer = new StringBuffer();
+        assertEquals("5,5 Pa", formatter.format(new Pressure(value, PressureUnit.PASCAL), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 kPa", formatter.format(new Pressure(value, PressureUnit.KILOPASCAL), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 bar", formatter.format(new Pressure(value, PressureUnit.BAR), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 atm", formatter.format(new Pressure(value, PressureUnit.ATMOSPHERE), buffer,
+                new FieldPosition(0)).toString());
+
+        buffer = new StringBuffer();
+        assertEquals("5,5 psi", formatter.format(new Pressure(value, PressureUnit.PSI), buffer,
+                new FieldPosition(0)).toString());
+    }
+
+    @Test
+    void testFormatAndConvertNumber() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PASCAL),
+                formatter.formatAndConvert(new BigDecimal("5.5"), PressureUnit.PASCAL));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL, PressureUnit.PASCAL),
+                formatter.formatAndConvert(new BigDecimal("1.0"), PressureUnit.KILOPASCAL));
+        assertEquals(formatter.format(5.5 * PASCALS_PER_PSI, PressureUnit.PASCAL),
+                formatter.formatAndConvert(new BigDecimal("5.5"), PressureUnit.PSI));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PSI),
+                formatter.formatAndConvert(new BigDecimal("5.5"), PressureUnit.PSI));
+    }
+
+    @Test
+    void testFormatAndConvertDouble() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PASCAL),
+                formatter.formatAndConvert(5.5, PressureUnit.PASCAL));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL, PressureUnit.PASCAL),
+                formatter.formatAndConvert(1.0, PressureUnit.KILOPASCAL));
+        assertEquals(formatter.format(5.5 * PASCALS_PER_PSI, PressureUnit.PASCAL),
+                formatter.formatAndConvert(5.5, PressureUnit.PSI));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PSI),
+                formatter.formatAndConvert(5.5, PressureUnit.PSI));
+    }
+
+    @Test
+    void testFormatAndConvertPressure() {
+        // test for metric system
+        var l = new Locale("es", "ES");
+
+        var formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PASCAL),
+                formatter.formatAndConvert(new Pressure(5.5, PressureUnit.PASCAL)));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL, PressureUnit.PASCAL),
+                formatter.formatAndConvert(new Pressure(1.0, PressureUnit.KILOPASCAL)));
+        assertEquals(formatter.format(5.5 * PASCALS_PER_PSI, PressureUnit.PASCAL),
+                formatter.formatAndConvert(new Pressure(5.5, PressureUnit.PSI)));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PSI),
+                formatter.formatAndConvert(new Pressure(5.5, PressureUnit.PSI)));
+    }
+
+    @Test
+    void testFormatAndConvertNumberAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PASCAL), formatter.formatAndConvert(
+                new BigDecimal("5.5"), PressureUnit.PASCAL, UnitSystem.METRIC));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL, PressureUnit.PASCAL), formatter.formatAndConvert(
+                new BigDecimal("1.0"), PressureUnit.KILOPASCAL, UnitSystem.METRIC));
+
+        assertEquals(formatter.format(5.5 * PASCALS_PER_PSI, PressureUnit.PASCAL), formatter.formatAndConvert(
+                new BigDecimal("5.5"), PressureUnit.PSI, UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PSI), formatter.formatAndConvert(
+                new BigDecimal("5.5"), PressureUnit.PSI, UnitSystem.IMPERIAL));
+
+        assertEquals(formatter.format(5.5 / PASCALS_PER_PSI, PressureUnit.PSI), formatter.formatAndConvert(
+                new BigDecimal("5.5"), PressureUnit.PASCAL, UnitSystem.IMPERIAL));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL / PASCALS_PER_PSI, PressureUnit.PSI),
+                formatter.formatAndConvert(new BigDecimal("1.0"), PressureUnit.KILOPASCAL, UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertDoubleAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PASCAL), formatter.formatAndConvert(
+                5.5, PressureUnit.PASCAL, UnitSystem.METRIC));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL, PressureUnit.PASCAL), formatter.formatAndConvert(
+                1.0, PressureUnit.KILOPASCAL, UnitSystem.METRIC));
+
+        assertEquals(formatter.format(5.5 * PASCALS_PER_PSI, PressureUnit.PASCAL), formatter.formatAndConvert(
+                5.5, PressureUnit.PSI, UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PSI), formatter.formatAndConvert(
+                5.5, PressureUnit.PSI, UnitSystem.IMPERIAL));
+
+        assertEquals(formatter.format(5.5 / PASCALS_PER_PSI, PressureUnit.PSI), formatter.formatAndConvert(
+                5.5, PressureUnit.PASCAL, UnitSystem.IMPERIAL));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL / PASCALS_PER_PSI, PressureUnit.PSI),
+                formatter.formatAndConvert(1.0, PressureUnit.KILOPASCAL, UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertPressureAndUnitSystem() {
+        var l = new Locale("es", "ES");
+
+        var formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PASCAL), formatter.formatAndConvert(
+                new Pressure(5.5, PressureUnit.PASCAL), UnitSystem.METRIC));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL, PressureUnit.PASCAL), formatter.formatAndConvert(
+                new Pressure(1.0, PressureUnit.KILOPASCAL), UnitSystem.METRIC));
+
+        assertEquals(formatter.format(5.5 * PASCALS_PER_PSI, PressureUnit.PASCAL), formatter.formatAndConvert(
+                new Pressure(5.5, PressureUnit.PSI), UnitSystem.METRIC));
+
+        // test for imperial system
+        l = new Locale("en", "US");
+
+        formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PSI), formatter.formatAndConvert(
+                new Pressure(5.5, PressureUnit.PSI), UnitSystem.IMPERIAL));
+
+        assertEquals(formatter.format(5.5 / PASCALS_PER_PSI, PressureUnit.PSI), formatter.formatAndConvert(
+                new Pressure(5.5, PressureUnit.PASCAL), UnitSystem.IMPERIAL));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL / PASCALS_PER_PSI, PressureUnit.PSI),
+                formatter.formatAndConvert(new Pressure(1.0, PressureUnit.KILOPASCAL), UnitSystem.IMPERIAL));
+    }
+
+    @Test
+    void testFormatAndConvertMetric() {
+        final var l = new Locale("es", "ES");
+
+        final var formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PASCAL),
+                formatter.formatAndConvertMetric(new BigDecimal("5.5"), PressureUnit.PASCAL));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL, PressureUnit.PASCAL),
+                formatter.formatAndConvertMetric(new BigDecimal("1.0"), PressureUnit.KILOPASCAL));
+        assertEquals(formatter.format(5.5 * PASCALS_PER_PSI, PressureUnit.PASCAL),
+                formatter.formatAndConvertMetric(new BigDecimal("5.5"), PressureUnit.PSI));
+    }
+
+    @Test
+    void testFormatAndConvertImperial() {
+        final var l = new Locale("en", "US");
+
+        final var formatter = new PressureFormatter(l);
+        formatter.setMaximumFractionDigits(2);
+
+        assertEquals(formatter.format(5.5, PressureUnit.PSI),
+                formatter.formatAndConvertImperial(new BigDecimal("5.5"), PressureUnit.PSI));
+
+        assertEquals(formatter.format(5.5 / PASCALS_PER_PSI, PressureUnit.PSI),
+                formatter.formatAndConvertImperial(new BigDecimal("5.5"), PressureUnit.PASCAL));
+        assertEquals(formatter.format(1.0 * PASCALS_PER_KILOPASCAL / PASCALS_PER_PSI, PressureUnit.PSI),
+                formatter.formatAndConvertImperial(new BigDecimal("1.0"), PressureUnit.KILOPASCAL));
+    }
+
+    @Test
+    void testGetAvailableLocales() {
+        final var locales = PressureFormatter.getAvailableLocales();
+        assertArrayEquals(locales, NumberFormat.getAvailableLocales());
+    }
+
+    @Test
+    void testGetSetMaximumFractionDigits() {
+        final var formatter = new PressureFormatter();
+
+        assertEquals(formatter.getMaximumFractionDigits(), NumberFormat.getInstance().getMaximumFractionDigits());
+
+        // set new value
+        formatter.setMaximumFractionDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMaximumFractionDigits());
+    }
+
+    @Test
+    void testGetSetMaximumIntegerDigits() {
+        final var formatter = new PressureFormatter();
+
+        assertEquals(formatter.getMaximumIntegerDigits(), NumberFormat.getInstance().getMaximumIntegerDigits());
+
+        // set new value
+        formatter.setMaximumIntegerDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMaximumIntegerDigits());
+    }
+
+    @Test
+    void testGetSetMinimumFractionDigits() {
+        final var formatter = new PressureFormatter();
+
+        assertEquals(formatter.getMinimumFractionDigits(), NumberFormat.getInstance().getMinimumFractionDigits());
+
+        // set new value
+        formatter.setMinimumFractionDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMinimumFractionDigits());
+    }
+
+    @Test
+    void testGetSetMinimumIntegerDigits() {
+        final var formatter = new PressureFormatter();
+
+        assertEquals(formatter.getMinimumIntegerDigits(), NumberFormat.getInstance().getMinimumIntegerDigits());
+
+        // set new value
+        formatter.setMinimumIntegerDigits(2);
+
+        // check correctness
+        assertEquals(2, formatter.getMinimumIntegerDigits());
+    }
+
+    @Test
+    void testGetSetRoundingMode() {
+        final var formatter = new PressureFormatter();
+
+        assertEquals(formatter.getRoundingMode(), NumberFormat.getInstance().getRoundingMode());
+
+        // set new value
+        formatter.setRoundingMode(RoundingMode.UNNECESSARY);
+
+        // check correctness
+        assertEquals(RoundingMode.UNNECESSARY, formatter.getRoundingMode());
+    }
+
+    @Test
+    void testIsSetGroupingUsed() {
+        final var formatter = new PressureFormatter();
+
+        assertEquals(formatter.isGroupingUsed(), NumberFormat.getInstance().isGroupingUsed());
+
+        // set new value
+        formatter.setGroupingUsed(!formatter.isGroupingUsed());
+
+        // check correctness
+        assertEquals(formatter.isGroupingUsed(), !NumberFormat.getInstance().isGroupingUsed());
+    }
+
+    @Test
+    void testIsSetParseIntegerOnly() {
+        final var formatter = new PressureFormatter();
+
+        assertEquals(formatter.isParseIntegerOnly(), NumberFormat.getInstance().isParseIntegerOnly());
+
+        // set new value
+        formatter.setParseIntegerOnly(!formatter.isParseIntegerOnly());
+
+        // check correctness
+        assertEquals(formatter.isParseIntegerOnly(), !NumberFormat.getInstance().isParseIntegerOnly());
+    }
+
+    @Test
+    void testGetSetValueAndUnitFormatPattern() {
+        final var formatter = new PressureFormatter();
+
+        assertEquals(MeasureFormatter.DEFAULT_VALUE_AND_UNIT_FORMAT_PATTERN, formatter.getValueAndUnitFormatPattern());
+
+        // new value
+        formatter.setValueAndUnitFormatPattern("{0}{1}");
+
+        // check correctness
+        assertEquals("{0}{1}", formatter.getValueAndUnitFormatPattern());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> formatter.setValueAndUnitFormatPattern(null));
+    }
+
+    @Test
+    void testGetUnitSystem() {
+        var formatter = new PressureFormatter(new Locale("es", "ES"));
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem());
+
+        formatter = new PressureFormatter(new Locale("en", "US"));
+        assertEquals(UnitSystem.IMPERIAL, formatter.getUnitSystem());
+    }
+
+    @Test
+    void testIsValidUnit() {
+        final var formatter = new PressureFormatter();
+
+        assertTrue(formatter.isValidUnit("Pa"));
+        assertTrue(formatter.isValidUnit("Pa "));
+
+        assertTrue(formatter.isValidUnit("kPa"));
+        assertTrue(formatter.isValidUnit("kPa "));
+
+        assertTrue(formatter.isValidUnit("bar"));
+        assertTrue(formatter.isValidUnit("bar "));
+
+        assertTrue(formatter.isValidUnit("atm"));
+        assertTrue(formatter.isValidUnit("atm "));
+
+        assertTrue(formatter.isValidUnit("psi"));
+        assertTrue(formatter.isValidUnit("psi "));
+    }
+
+    @Test
+    void testIsValidMeasurement() {
+        final var formatter = new PressureFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 Pa";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 kPa";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 bar";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 atm";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 psi";
+        assertTrue(formatter.isValidMeasurement(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isValidMeasurement(text));
+
+        text = "m";
+        assertFalse(formatter.isValidMeasurement(text));
+    }
+
+    @Test
+    void testIsMetricUnit() {
+        final var formatter = new PressureFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 Pa";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 kPa";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 bar";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 atm";
+        assertTrue(formatter.isMetricUnit(text));
+
+        text = "5,5 psi";
+        assertFalse(formatter.isMetricUnit(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isMetricUnit(text));
+    }
+
+    @Test
+    void testIsImperialUnit() {
+        final var formatter = new PressureFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 Pa";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 kPa";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 bar";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 atm";
+        assertFalse(formatter.isImperialUnit(text));
+
+        text = "5,5 psi";
+        assertTrue(formatter.isImperialUnit(text));
+
+        text = "5,5 s";
+        assertFalse(formatter.isImperialUnit(text));
+    }
+
+    @Test
+    void testGetUnitSystemFromSource() {
+        final var formatter = new PressureFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 Pa";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 kPa";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 bar";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 atm";
+        assertEquals(UnitSystem.METRIC, formatter.getUnitSystem(text));
+
+        text = "5,5 psi";
+        assertEquals(UnitSystem.IMPERIAL, formatter.getUnitSystem(text));
+
+        text = "5,5 s";
+        assertNull(formatter.getUnitSystem(text));
+    }
+
+    @Test
+    void testParse() throws ParseException, UnknownUnitException {
+        final var formatter = new PressureFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 Pa";
+        var p = formatter.parse(text);
+        assertEquals(5.5, p.getValue().doubleValue(), 0.0);
+        assertEquals(PressureUnit.PASCAL, p.getUnit());
+
+        text = "5,5 kPa";
+        p = formatter.parse(text);
+        assertEquals(5.5, p.getValue().doubleValue(), 0.0);
+        assertEquals(PressureUnit.KILOPASCAL, p.getUnit());
+
+        text = "5,5 bar";
+        p = formatter.parse(text);
+        assertEquals(5.5, p.getValue().doubleValue(), 0.0);
+        assertEquals(PressureUnit.BAR, p.getUnit());
+
+        text = "5,5 atm";
+        p = formatter.parse(text);
+        assertEquals(5.5, p.getValue().doubleValue(), 0.0);
+        assertEquals(PressureUnit.ATMOSPHERE, p.getUnit());
+
+        text = "5,5 psi";
+        p = formatter.parse(text);
+        assertEquals(5.5, p.getValue().doubleValue(), 0.0);
+        assertEquals(PressureUnit.PSI, p.getUnit());
+
+        // Force UnknownUnitException
+        assertThrows(UnknownUnitException.class, () -> formatter.parse("5,5 s"));
+
+        // Force ParseException
+        assertThrows(ParseException.class, () -> formatter.parse("m"));
+    }
+
+    @Test
+    void testFindUnit() {
+        final var formatter = new PressureFormatter(new Locale("es", "ES"));
+
+        var text = "5,5 Pa";
+        assertEquals(PressureUnit.PASCAL, formatter.findUnit(text));
+
+        text = "5,5 kPa";
+        assertEquals(PressureUnit.KILOPASCAL, formatter.findUnit(text));
+
+        text = "5,5 bar";
+        assertEquals(PressureUnit.BAR, formatter.findUnit(text));
+
+        text = "5,5 atm";
+        assertEquals(PressureUnit.ATMOSPHERE, formatter.findUnit(text));
+
+        text = "5,5 psi";
+        assertEquals(PressureUnit.PSI, formatter.findUnit(text));
+
+        text = "5,5 s";
+        assertNull(formatter.findUnit(text));
+    }
+
+    @Test
+    void testGetUnitSymbol() {
+        final var formatter = new PressureFormatter();
+
+        assertEquals(PressureFormatter.PASCAL, formatter.getUnitSymbol(PressureUnit.PASCAL));
+        assertEquals(PressureFormatter.KILOPASCAL, formatter.getUnitSymbol(PressureUnit.KILOPASCAL));
+        assertEquals(PressureFormatter.BAR, formatter.getUnitSymbol(PressureUnit.BAR));
+        assertEquals(PressureFormatter.ATMOSPHERE, formatter.getUnitSymbol(PressureUnit.ATMOSPHERE));
+        assertEquals(PressureFormatter.PSI, formatter.getUnitSymbol(PressureUnit.PSI));
+    }
+}

--- a/src/test/java/com/irurueta/units/PressureTest.java
+++ b/src/test/java/com/irurueta/units/PressureTest.java
@@ -1,0 +1,568 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PressureTest {
+
+    private static final double ERROR = 1e-6;
+
+    @Test
+    void testConstructor() {
+        // test empty constructor
+        var p = new Pressure();
+
+        // check
+        assertNull(p.getValue());
+        assertNull(p.getUnit());
+
+        // test constructor with value and unit
+        p = new Pressure(323, PressureUnit.PASCAL);
+
+        // check
+        assertEquals(323, p.getValue());
+        assertEquals(PressureUnit.PASCAL, p.getUnit());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> new Pressure(null, PressureUnit.PASCAL));
+        assertThrows(IllegalArgumentException.class, () -> new Pressure(323, null));
+    }
+
+    @Test
+    void testEquals() {
+        final var value = new Random().nextDouble();
+        final var p1 = new Pressure(value, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value, PressureUnit.PASCAL);
+        final var p3 = new Pressure(value + 1.0, PressureUnit.PASCAL);
+        final var p4 = new Pressure(value, PressureUnit.KILOPASCAL);
+
+        //noinspection EqualsWithItself
+        assertEquals(p1, p1);
+        assertEquals(p1, p2);
+        assertNotEquals(p1, p3);
+        assertNotEquals(p1, p4);
+
+        assertNotEquals(null, p1);
+        assertNotEquals(p1, new Object());
+    }
+
+    @Test
+    void tetHashCode() {
+        final var value = new Random().nextDouble();
+        final var p1 = new Pressure(value, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value, PressureUnit.PASCAL);
+        final var p3 = new Pressure(value + 1.0, PressureUnit.PASCAL);
+        final var p4 = new Pressure(value, PressureUnit.KILOPASCAL);
+
+        assertEquals(p1.hashCode(), p1.hashCode());
+        assertEquals(p1.hashCode(), p2.hashCode());
+        assertNotEquals(p1.hashCode(), p3.hashCode());
+        assertNotEquals(p1.hashCode(), p4.hashCode());
+    }
+
+    @Test
+    void testEqualsWithTolerance() {
+        final var value = new Random().nextDouble();
+        final var p1 = new Pressure(value, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value, PressureUnit.PASCAL);
+        final var p3 = new Pressure(value + 0.5 * ERROR, PressureUnit.PASCAL);
+        final var p4 = new Pressure(value, PressureUnit.KILOPASCAL);
+        final var p5 = new Pressure(PressureConverter.convert(value, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), PressureUnit.KILOPASCAL);
+
+        assertTrue(p1.equals(p1, 0.0));
+        assertTrue(p1.equals(p2, 0.0));
+        assertFalse(p1.equals(p3, 0.0));
+        assertTrue(p1.equals(p3, ERROR));
+        assertFalse(p1.equals(p4, ERROR));
+        assertTrue(p1.equals(p5, ERROR));
+
+        assertFalse(p1.equals(null, ERROR));
+    }
+
+    @Test
+    void testGetSetValue() {
+        final var p = new Pressure(1, PressureUnit.PASCAL);
+
+        // check
+        assertEquals(1, p.getValue());
+
+        // set new value
+        p.setValue(2.5);
+
+        // check
+        assertEquals(2.5, p.getValue());
+
+        //force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> p.setValue(null));
+    }
+
+    @Test
+    void testGetSetUnit() {
+        final var p = new Pressure(1, PressureUnit.PASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p.getUnit());
+
+        // set new value
+        p.setUnit(PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureUnit.KILOPASCAL, p.getUnit());
+
+        // force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> p.setUnit(null));
+    }
+
+    @Test
+    void testAdd1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Pressure.add(value1, PressureUnit.PASCAL, value2,
+                PressureUnit.PASCAL, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureConverter.convert(value1 + value2, PressureUnit.PASCAL,
+                        PressureUnit.KILOPASCAL), result, ERROR);
+    }
+
+    @Test
+    void testAdd2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Pressure.add(new BigDecimal(value1), PressureUnit.PASCAL,
+                new BigDecimal(value2), PressureUnit.PASCAL, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureConverter.convert(value1 + value2, PressureUnit.PASCAL,
+                        PressureUnit.KILOPASCAL), result.doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value2, PressureUnit.PASCAL);
+
+        final var result = new Pressure(0.0, PressureUnit.KILOPASCAL);
+        Pressure.add(p1, p2, result);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.PASCAL, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 + value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value2, PressureUnit.PASCAL);
+
+        final var result = Pressure.addAndReturnNew(p1, p2, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.PASCAL, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 + value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+
+        final var result = p1.addAndReturnNew(value2, PressureUnit.PASCAL, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 + value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+
+        final var result = p1.addAndReturnNew(new BigDecimal(value2), PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 + value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAddAndReturnNew4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value2, PressureUnit.PASCAL);
+
+        final var result = p1.addAndReturnNew(p2, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.PASCAL, p2.getUnit());
+        assertEquals(p2.getValue().doubleValue(), value2, 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 + value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+
+        p1.add(value2, PressureUnit.PASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1 + value2, p1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd5() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+
+        p1.add(new BigDecimal(value2), PressureUnit.PASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1 + value2, p1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testAdd6() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value2, PressureUnit.PASCAL);
+
+        p1.add(p2);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1 + value2, p1.getValue().doubleValue(), ERROR);
+
+        assertEquals(PressureUnit.PASCAL, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testAdd7() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value2, PressureUnit.PASCAL);
+
+        final var result = new Pressure(0.0, PressureUnit.KILOPASCAL);
+        p1.add(p2, result);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.PASCAL, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 + value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Pressure.subtract(value1, PressureUnit.PASCAL, value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureConverter.convert(value1 - value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result, ERROR);
+    }
+
+    @Test
+    void testSubtract2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var result = Pressure.subtract(new BigDecimal(value1), PressureUnit.PASCAL, new BigDecimal(value2),
+                PressureUnit.PASCAL, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureConverter.convert(value1 - value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value2, PressureUnit.PASCAL);
+
+        final var result = new Pressure(0.0, PressureUnit.KILOPASCAL);
+        Pressure.subtract(p1, p2, result);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.PASCAL, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 - value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew1() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value2, PressureUnit.PASCAL);
+
+        final var result = Pressure.subtractAndReturnNew(p1, p2, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.PASCAL, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 - value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew2() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+
+        final var result = p1.subtractAndReturnNew(value2, PressureUnit.PASCAL, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 - value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew3() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+
+        final var result = p1.subtractAndReturnNew(new BigDecimal(value2), PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 - value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtractAndReturnNew4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value2, PressureUnit.PASCAL);
+
+        final var result = p1.subtractAndReturnNew(p2, PressureUnit.KILOPASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.PASCAL, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 - value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract4() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+
+        p1.subtract(value2, PressureUnit.PASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1 - value2, p1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract5() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+
+        p1.subtract(new BigDecimal(value2), PressureUnit.PASCAL);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1 - value2, p1.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSubtract6() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value2, PressureUnit.PASCAL);
+
+        p1.subtract(p2);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1 - value2, p1.getValue().doubleValue(), ERROR);
+
+        assertEquals(PressureUnit.PASCAL, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+    }
+
+    @Test
+    void testSubtract7() {
+        final var r = new Random();
+        final var value1 = r.nextDouble();
+        final var value2 = r.nextDouble();
+
+        final var p1 = new Pressure(value1, PressureUnit.PASCAL);
+        final var p2 = new Pressure(value2, PressureUnit.PASCAL);
+
+        final var result = new Pressure(0.0, PressureUnit.KILOPASCAL);
+        p1.subtract(p2, result);
+
+        // check
+        assertEquals(PressureUnit.PASCAL, p1.getUnit());
+        assertEquals(value1, p1.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.PASCAL, p2.getUnit());
+        assertEquals(value2, p2.getValue().doubleValue(), 0.0);
+
+        assertEquals(PressureUnit.KILOPASCAL, result.getUnit());
+        assertEquals(PressureConverter.convert(value1 - value2, PressureUnit.PASCAL,
+                PressureUnit.KILOPASCAL), result.getValue().doubleValue(), ERROR);
+    }
+
+    @Test
+    void testSerializeDeserialize() throws IOException, ClassNotFoundException {
+        final var value = new Random().nextDouble();
+        final var p1 = new Pressure(value, PressureUnit.PASCAL);
+
+        final var bytes = SerializationHelper.serialize(p1);
+        final var p2 = SerializationHelper.deserialize(bytes);
+
+        assertEquals(p1, p2);
+        assertNotSame(p1, p2);
+    }
+}

--- a/src/test/java/com/irurueta/units/PressureUnitTest.java
+++ b/src/test/java/com/irurueta/units/PressureUnitTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Alberto Irurueta Carro (alberto@irurueta.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.irurueta.units;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PressureUnitTest {
+
+    @Test
+    void testGetUnitSystem() {
+        assertEquals(UnitSystem.METRIC, PressureUnit.getUnitSystem(PressureUnit.PASCAL));
+        assertEquals(UnitSystem.METRIC, PressureUnit.getUnitSystem(PressureUnit.KILOPASCAL));
+        assertEquals(UnitSystem.METRIC, PressureUnit.getUnitSystem(PressureUnit.BAR));
+        assertEquals(UnitSystem.METRIC, PressureUnit.getUnitSystem(PressureUnit.ATMOSPHERE));
+        assertEquals(UnitSystem.IMPERIAL, PressureUnit.getUnitSystem(PressureUnit.PSI));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> PressureUnit.getUnitSystem(null));
+    }
+
+    @Test
+    void testGetMetricUnits() {
+        final var metricUnits = PressureUnit.getMetricUnits();
+        final var imperialUnits = PressureUnit.getImperialUnits();
+
+        for (final var metricUnit : metricUnits) {
+            assertTrue(PressureUnit.isMetric(metricUnit));
+            assertFalse(PressureUnit.isImperial(metricUnit));
+        }
+
+        assertEquals(metricUnits.length + imperialUnits.length, PressureUnit.values().length);
+    }
+
+    @Test
+    void testGetImperialUnits() {
+        final var metricUnits = PressureUnit.getMetricUnits();
+        final var imperialUnits = PressureUnit.getImperialUnits();
+
+        for (final var imperialUnit : imperialUnits) {
+            assertTrue(PressureUnit.isImperial(imperialUnit));
+            assertFalse(PressureUnit.isMetric(imperialUnit));
+        }
+
+        assertEquals(metricUnits.length + imperialUnits.length, PressureUnit.values().length);
+    }
+
+    @Test
+    void testIsMetric() {
+        assertTrue(PressureUnit.isMetric(PressureUnit.PASCAL));
+        assertTrue(PressureUnit.isMetric(PressureUnit.KILOPASCAL));
+        assertTrue(PressureUnit.isMetric(PressureUnit.BAR));
+        assertTrue(PressureUnit.isMetric(PressureUnit.ATMOSPHERE));
+        assertFalse(PressureUnit.isMetric(PressureUnit.PSI));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> PressureUnit.isMetric(null));
+    }
+
+    @Test
+    void testIsImperial() {
+        assertFalse(PressureUnit.isImperial(PressureUnit.PASCAL));
+        assertFalse(PressureUnit.isImperial(PressureUnit.KILOPASCAL));
+        assertFalse(PressureUnit.isImperial(PressureUnit.BAR));
+        assertFalse(PressureUnit.isImperial(PressureUnit.ATMOSPHERE));
+        assertTrue(PressureUnit.isImperial(PressureUnit.PSI));
+
+        // Force IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> PressureUnit.isImperial(null));
+    }
+}


### PR DESCRIPTION
Adds four new measurement families — Force, Pressure, Energy, and Power — following the library's existing `<X>`/`<X>Unit`/`<X>Converter`/`<X>Formatter` pattern, complete with unit tests and updated documentation.

- ✨ Add `Force`/`ForceUnit`/`ForceConverter`/`ForceFormatter` supporting `NEWTON`, `KILONEWTON`, `POUND_FORCE`, `DYNE`, `KILOGRAM_FORCE`
- ✨ Add `Pressure`/`PressureUnit`/`PressureConverter`/`PressureFormatter` supporting `PASCAL`, `KILOPASCAL`, `BAR`, `ATMOSPHERE`, `PSI`
- ✨ Add `Energy`/`EnergyUnit`/`EnergyConverter`/`EnergyFormatter` supporting `JOULE`, `KILOJOULE`, `CALORIE`, `KILOCALORIE`, `KILOWATT_HOUR`, `BTU`
- ✨ Add `Power`/`PowerUnit`/`PowerConverter`/`PowerFormatter` supporting `WATT`, `KILOWATT`, `MEGAWATT`, `HORSEPOWER`
- ✅ Add corresponding test classes for each new family (`*Test`, `*ConverterTest`, `*FormatterTest`, `*UnitTest`)
- 📝 Update `README.md`, the Antora `index.adoc` and `supported-units.adoc` pages, and the package Javadoc to document the new measurement families

Closes #13.
